### PR TITLE
Don't block the main process on dev

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -136,4 +136,3 @@ Task.async(fn ->
 
   Process.sleep(:infinity)
 end)
-|> Task.await(:infinity)


### PR DESCRIPTION
The Phoenix application will run forever until the parent process dies. Removing the await ensures that the main process is not blocked and you can run `iex -S dev` and work in the console.