### PR TITLE
Do not fingerprint error reason

### DIFF
--- a/lib/error_tracker/migrations/postgres/v01.ex
+++ b/lib/error_tracker/migrations/postgres/v01.ex
@@ -22,6 +22,7 @@ defmodule ErrorTracker.Migrations.Postgres.V01 do
 
     create table(:error_tracker_occurrences, prefix: prefix) do
       add :context, :map, null: false
+      add :reason, :text, null: false
       add :stacktrace, :map, null: false
       add :error_id, references(:error_tracker_errors, on_delete: :delete_all), null: false
 

--- a/lib/error_tracker/schemas/occurrence.ex
+++ b/lib/error_tracker/schemas/occurrence.ex
@@ -10,6 +10,7 @@ defmodule ErrorTracker.Occurrence do
 
   schema "error_tracker_occurrences" do
     field :context, :map
+    field :reason, :string
 
     embeds_one :stacktrace, ErrorTracker.Stacktrace
     belongs_to :error, ErrorTracker.Error

--- a/lib/error_tracker/web/live/show.html.heex
+++ b/lib/error_tracker/web/live/show.html.heex
@@ -16,7 +16,7 @@
 <div class="grid grid-cols-1 md:grid-cols-4 md:space-x-3 mt-6 gap-2">
   <div class="px-3 md:col-span-3 md:border-r-2 md:border-gray-500 space-y-8">
     <.section title="Full message">
-      <pre class="overflow-auto p-4 bg-gray-600"><%= @error.reason %></pre>
+      <pre class="overflow-auto p-4 bg-gray-600"><%= @occurrence.reason %></pre>
     </.section>
 
     <.section title="Source">


### PR DESCRIPTION
Including the error reason among the fingerprinted parameters caused wrong error grouping in certain scenarios such as accessing not-existing map fields.

This pull request stores only the original reason in the error itself and then records each occurrence reason. This ensures that errors are grouped together even though the reason has slight changes.

I am not sure if it is worth to keep the reason in the error itself, but we can always remove it later so this doesn't have to be decided now.

Closes #15 