### PR TITLE
Highlight and increase clickable area in error listing

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2,3 +2,6 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
+th a {
+    display: block;
+}

--- a/lib/error_tracker/web/live/dashboard.html.heex
+++ b/lib/error_tracker/web/live/dashboard.html.heex
@@ -52,19 +52,19 @@
           No errors to show 🎉
         </td>
       </tr>
-      <tr :for={error <- @errors} class="border-b bg-gray-800 border-gray-700">
+      <tr :for={error <- @errors} class="border-b bg-gray-800 border-gray-700 hover:bg-gray-700">
         <th
           scope="row"
           class="px-4 py-4 font-medium text-white whitespace-nowrap text-ellipsis overflow-hidden"
         >
           <.link navigate={error_path(@socket, error)}>
             (<%= sanitize_module(error.kind) %>) <%= error.reason %>
+            <p class="font-normal text-gray-400">
+              <%= sanitize_module(error.source_function) %>
+              <br />
+              <%= error.source_line %>
+            </p>
           </.link>
-          <p class="font-normal text-gray-400">
-            <%= sanitize_module(error.source_function) %>
-            <br />
-            <%= error.source_line %>
-          </p>
         </th>
         <td class="px-4 py-4">
           <p>Last: <%= format_datetime(error.last_occurrence_at) %></p>


### PR DESCRIPTION
Highlight the error item and expand the clickable area when browsing the error listing to increase UX.

[error_tracker_highlight_and_expand_clickable_area.webm](https://github.com/user-attachments/assets/c6f74dfb-b5b8-4814-bc27-74919b4ae30c)
