### PR TITLE
Force primary key type on migrations

### DIFF
--- a/lib/error_tracker/migration/postgres/v01.ex
+++ b/lib/error_tracker/migration/postgres/v01.ex
@@ -6,7 +6,10 @@ defmodule ErrorTracker.Migration.Postgres.V01 do
   def up(%{create_schema: create_schema, prefix: prefix}) do
     if create_schema, do: execute("CREATE SCHEMA IF NOT EXISTS #{prefix}")
 
-    create table(:error_tracker_errors, prefix: prefix) do
+    create table(:error_tracker_errors,
+             primary_key: [name: :id, type: :bigserial],
+             prefix: prefix
+           ) do
       add :kind, :string, null: false
       add :reason, :text, null: false
       add :source_line, :text, null: false
@@ -20,11 +23,16 @@ defmodule ErrorTracker.Migration.Postgres.V01 do
 
     create unique_index(:error_tracker_errors, [:fingerprint], prefix: prefix)
 
-    create table(:error_tracker_occurrences, prefix: prefix) do
+    create table(:error_tracker_occurrences,
+             primary_key: [name: :id, type: :bigserial],
+             prefix: prefix
+           ) do
       add :context, :map, null: false
       add :reason, :text, null: false
       add :stacktrace, :map, null: false
-      add :error_id, references(:error_tracker_errors, on_delete: :delete_all), null: false
+
+      add :error_id, references(:error_tracker_errors, on_delete: :delete_all, type: :bigserial),
+        null: false
 
       timestamps(type: :utc_datetime_usec, updated_at: false)
     end


### PR DESCRIPTION
This MR fixes a bug found on #27 , which arises when your application is configured to use other types of field which is not `bigserial` for primary keys.

After this change, the migrations needed for the `ErrorTracker` enforce the type `bigserial` for its primary keys.

---

As for people that already tried to implement the library on their systems, they need to down migrate the migration in which they introduced the library and run it again after this change is released.

In normal situations we would run a migration to fix existing systems, but given that the library is less than a week old and this bug avoids using the library at all, it is safe to say that users impacted by this will not have any data stored.

---

Closes #27 