### PR TITLE
Allow mounting the dashboard without parens

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,6 +1,10 @@
 # Used by "mix format"
+locals_without_parens = [error_tracker_dashboard: 1, error_tracker_dashboard: 2]
+
 [
   import_deps: [:ecto, :ecto_sql, :plug, :phoenix],
   inputs: ["{mix,.formatter,dev,dev.*}.exs", "{config,lib,test}/**/*.{heex,ex,exs}"],
-  plugins: [Phoenix.LiveView.HTMLFormatter]
+  plugins: [Phoenix.LiveView.HTMLFormatter],
+  locals_without_parens: locals_without_parens,
+  export: [locals_without_parens: locals_without_parens]
 ]

--- a/dev.exs
+++ b/dev.exs
@@ -109,7 +109,7 @@ defmodule ErrorTrackerDevWeb.Router do
     get "/exit", ErrorTrackerDevWeb.PageController, :exit
 
     scope "/dev" do
-      error_tracker_dashboard("/errors")
+      error_tracker_dashboard "/errors"
     end
   end
 end


### PR DESCRIPTION
Allows omitting parens for consistency with other packages such as Phoenix Live Dashboard or Oban Web.

```elixir
# You can now write this
error_tracker_dashboard "/errors"

# It won't be automatically formatted to 
error_tracker_dashboard("/errors")
```
