### PR TITLE
Fix some exceptions reporting

### DIFF
--- a/lib/error_tracker.ex
+++ b/lib/error_tracker.ex
@@ -102,8 +102,6 @@ defmodule ErrorTracker do
   messages.
   """
   def report(exception, stacktrace, given_context \\ %{}) do
-    IO.inspect(exception)
-
     {kind, reason} = normalize_exception(exception, stacktrace)
     {:ok, stacktrace} = ErrorTracker.Stacktrace.new(stacktrace)
     {:ok, error} = Error.new(kind, reason, stacktrace)

--- a/lib/error_tracker.ex
+++ b/lib/error_tracker.ex
@@ -173,7 +173,7 @@ defmodule ErrorTracker do
 
   defp normalize_exception({kind, ex}, stacktrace) do
     case Exception.normalize(kind, ex, stacktrace) do
-      %struct{} ->
+      %struct{} = ex ->
         {to_string(struct), Exception.message(ex)}
 
       other ->

--- a/lib/error_tracker.ex
+++ b/lib/error_tracker.ex
@@ -94,12 +94,8 @@ defmodule ErrorTracker do
   * An exception struct: the module of the exception is stored along with
   the exception message.
 
-  * A `{kind, exception}` tuple in which the `exception` is a struct: it
-  behaves the same as when passing just the exception struct.
-
-  * A `{kind, reason}` tuple: it stores the kind and the message itself cast
-  to strings, which is useful for some errors like EXIT signals or custom error
-  messages.
+  * A `{kind, exception}` tuple in which case the information is converted to
+  an Elixir exception (if possible) and stored.
   """
   def report(exception, stacktrace, given_context \\ %{}) do
     {kind, reason} = normalize_exception(exception, stacktrace)

--- a/lib/error_tracker/schemas/error.ex
+++ b/lib/error_tracker/schemas/error.ex
@@ -29,10 +29,11 @@ defmodule ErrorTracker.Error do
   @doc false
   def new(kind, reason, stacktrace = %ErrorTracker.Stacktrace{}) do
     source = ErrorTracker.Stacktrace.source(stacktrace)
+    source_line = if source.file, do: "#{source.file}:#{source.line}", else: "nofile"
 
     params = [
       kind: to_string(kind),
-      source_line: "#{source.file}:#{source.line}",
+      source_line: source_line,
       source_function: "#{source.module}.#{source.function}/#{source.arity}"
     ]
 

--- a/lib/error_tracker/schemas/stacktrace.ex
+++ b/lib/error_tracker/schemas/stacktrace.ex
@@ -27,7 +27,7 @@ defmodule ErrorTracker.Stacktrace do
           application: to_string(application),
           module: module |> to_string() |> String.replace_prefix("Elixir.", ""),
           function: to_string(function),
-          arity: arity,
+          arity: normalize_arity(arity),
           file: to_string(opts[:file]),
           line: opts[:line]
         }
@@ -38,6 +38,9 @@ defmodule ErrorTracker.Stacktrace do
     |> Ecto.Changeset.cast_embed(:lines, with: &line_changeset/2)
     |> Ecto.Changeset.apply_action(:new)
   end
+
+  defp normalize_arity(a) when is_integer(a), do: a
+  defp normalize_arity(a) when is_list(a), do: length(a)
 
   defp line_changeset(line = %__MODULE__.Line{}, params) do
     Ecto.Changeset.cast(line, params, ~w[application module function arity file line]a)

--- a/lib/error_tracker/web/live/show.html.heex
+++ b/lib/error_tracker/web/live/show.html.heex
@@ -48,7 +48,7 @@
                 <td class="px-2 align-top"><pre>(<%= line.application || @app %>)</pre></td>
                 <td>
                   <pre><%= "#{sanitize_module(line.module)}.#{line.function}/#{line.arity}" %>
-                <%= "#{line.file}.#{line.line}" %></pre>
+                <%= if line.line, do: "#{line.file}:#{line.line}", else: "nofile" %></pre>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
This change updates how some Erlang errors are handled and ensure they are stored and shown properly.

The root issue was that some Erlang errors are received as tuples and we need to convert them to Elixir exception the same way as Phoenix does on their Error pages, by calling `Exception.normalize`.

We also fixed storing and showing stractrace information on those cases in which no file is reported.

Closes #35