### PR TITLE
Fix prefix usage in PostgreSQL

### DIFF
--- a/lib/error_tracker/repo.ex
+++ b/lib/error_tracker/repo.ex
@@ -32,7 +32,7 @@ defmodule ErrorTracker.Repo do
 
     defaults =
       case repo.__adapter__() do
-        Ecto.Adapter.Postgresql ->
+        Ecto.Adapters.Postgres ->
           [prefix: Application.get_env(:error_tracker, :prefix, "public")]
 
         _ ->


### PR DESCRIPTION
In #31 we added a bug which caused exceptions when storing errors in PostgreSQL when using a custom prefix.

This change fixes the issue.