### PR TITLE
Telemetry events

### DIFF
--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -126,3 +126,11 @@ You can also use `ErrorTracker.report/3` and set some custom context that will b
 ErrorTracker also provides a dashboard built with Phoenix LiveView that can be used to see and manage the recorded errors.
 
 This is completely optional, and you can find more information about it in the `ErrorTracker.Web` module documentation.
+
+## Notifications
+
+We currently do not support notifications out of the box.
+
+However, we provideo some detailed Telemetry events that you may use to implement your own notifications following your custom rules and notification channels.
+
+If you want to take a look at the events you can attach to, take a look at `ErrorTracker.Telemetry` module documentation.

--- a/lib/error_tracker.ex
+++ b/lib/error_tracker.ex
@@ -66,6 +66,7 @@ defmodule ErrorTracker do
 
   alias ErrorTracker.Error
   alias ErrorTracker.Repo
+  alias ErrorTracker.Telemetry
 
   @doc """
   Report an exception to be stored.
@@ -110,9 +111,14 @@ defmodule ErrorTracker do
         conflict_target: :fingerprint
       )
 
-    error
-    |> Ecto.build_assoc(:occurrences, stacktrace: stacktrace, context: context, reason: reason)
-    |> Repo.insert!()
+    occurrence =
+      error
+      |> Ecto.build_assoc(:occurrences, stacktrace: stacktrace, context: context, reason: reason)
+      |> Repo.insert!()
+
+    Telemetry.execute_new_occurrence(occurrence)
+
+    occurrence
   end
 
   @doc """

--- a/lib/error_tracker.ex
+++ b/lib/error_tracker.ex
@@ -119,7 +119,10 @@ defmodule ErrorTracker do
   def resolve(error = %Error{status: :unresolved}) do
     changeset = Ecto.Changeset.change(error, status: :resolved)
 
-    Repo.update(changeset)
+    with {:ok, updated_error} <- Repo.update(changeset) do
+      Telemetry.resolved_error(updated_error)
+      {:ok, updated_error}
+    end
   end
 
   @doc """
@@ -128,7 +131,10 @@ defmodule ErrorTracker do
   def unresolve(error = %Error{status: :resolved}) do
     changeset = Ecto.Changeset.change(error, status: :unresolved)
 
-    Repo.update(changeset)
+    with {:ok, updated_error} <- Repo.update(changeset) do
+      Telemetry.unresolved_error(updated_error)
+      {:ok, updated_error}
+    end
   end
 
   @doc """

--- a/lib/error_tracker/repo.ex
+++ b/lib/error_tracker/repo.ex
@@ -17,8 +17,8 @@ defmodule ErrorTracker.Repo do
     dispatch(:get!, [queryable, id], opts)
   end
 
-  def get_by(queryable, filters, opts \\ []) do
-    dispatch(:get_by, [queryable, filters], opts)
+  def one(queryable, opts \\ []) do
+    dispatch(:one, [queryable], opts)
   end
 
   def all(queryable, opts \\ []) do

--- a/lib/error_tracker/repo.ex
+++ b/lib/error_tracker/repo.ex
@@ -17,6 +17,10 @@ defmodule ErrorTracker.Repo do
     dispatch(:get!, [queryable, id], opts)
   end
 
+  def get_by(queryable, filters, opts \\ []) do
+    dispatch(:get_by, [queryable, filters], opts)
+  end
+
   def all(queryable, opts \\ []) do
     dispatch(:all, [queryable], opts)
   end

--- a/lib/error_tracker/telemetry.ex
+++ b/lib/error_tracker/telemetry.ex
@@ -1,6 +1,45 @@
 defmodule ErrorTracker.Telemetry do
   @moduledoc """
-  TODO
+  Telemetry events of ErrorTracker.
+
+  ErrorTracker emits some events to allow third parties to receive information
+  of errors and occurrences stored.
+
+  We emit four type of events which allows to track the lifetime of errors of
+  your application.
+
+  ### Error events
+
+  Those occur during the lifetime of an error:
+
+  * `[:error_tracker, :error, :new]`: is emitted when a new error is stored and
+  no previous occurrences were known.
+
+  * `[:error_tracker, :error, :resolved]`: is emitted when a new error is marked
+  as resolved on the UI.
+
+  * `[:error_tracker, :error, :unresolved]`: is emitted when a new error is
+  marked as unresolved on the UI or a new occurrence is registered, moving the
+  error to the unresolved state.
+
+  ### Occurrence events
+
+  There is only one event emitted for occurrences:
+
+  * `[:error_tracker, :occurrence, :new]`: is emitted when a new occurrence is
+  stored.
+
+  ### Measures and metadata
+
+  Each event is emitted with some measures and metadata, which can be used to
+  receive information without having to query the database again:
+
+  | event                                   | measures       | metadata      |
+  | --------------------------------------- | -------------- | ------------- |
+  | `[:error_tracker, :error, :new]`        | `:system_time` | `:error`      |
+  | `[:error_tracker, :error, :unresolved]` | `:system_time` | `:error`      |
+  | `[:error_tracker, :error, :resolved]`   | `:system_time` | `:error`      |
+  | `[:error_tracker, :occurrence, :new]`   | `:system_time` | `:occurrence` |
   """
 
   @doc false

--- a/lib/error_tracker/telemetry.ex
+++ b/lib/error_tracker/telemetry.ex
@@ -3,9 +3,21 @@ defmodule ErrorTracker.Telemetry do
   TODO
   """
 
-  def execute_new_occurrence(occurrence) do
+  @doc false
+  def new_error(error) do
     measurements = %{system_time: System.system_time()}
-    metadata = %{occurrence: occurrence}
-    :telemetry.execute([:error_tracker, :new_occurrence], measurements, metadata)
+    :telemetry.execute([:error_tracker, :new_error], measurements, %{error: error})
+  end
+
+  @doc false
+  def unresolved_error(error) do
+    measurements = %{system_time: System.system_time()}
+    :telemetry.execute([:error_tracker, :unresolved_error], measurements, %{error: error})
+  end
+
+  @doc false
+  def new_occurrence(occurrence) do
+    measurements = %{system_time: System.system_time()}
+    :telemetry.execute([:error_tracker, :new_occurrence], measurements, %{occurrence: occurrence})
   end
 end

--- a/lib/error_tracker/telemetry.ex
+++ b/lib/error_tracker/telemetry.ex
@@ -16,6 +16,12 @@ defmodule ErrorTracker.Telemetry do
   end
 
   @doc false
+  def resolved_error(error) do
+    measurements = %{system_time: System.system_time()}
+    :telemetry.execute([:error_tracker, :unresolved_error], measurements, %{error: error})
+  end
+
+  @doc false
   def new_occurrence(occurrence) do
     measurements = %{system_time: System.system_time()}
     :telemetry.execute([:error_tracker, :new_occurrence], measurements, %{occurrence: occurrence})

--- a/lib/error_tracker/telemetry.ex
+++ b/lib/error_tracker/telemetry.ex
@@ -7,7 +7,7 @@ defmodule ErrorTracker.Telemetry do
 
   ### Error events
 
-  Those occur during the lifetime of an error:
+  Those occur during the life cycle of an error:
 
   * `[:error_tracker, :error, :new]`: is emitted when a new error is stored and
   no previous occurrences were known.

--- a/lib/error_tracker/telemetry.ex
+++ b/lib/error_tracker/telemetry.ex
@@ -1,0 +1,11 @@
+defmodule ErrorTracker.Telemetry do
+  @moduledoc """
+  TODO
+  """
+
+  def execute_new_occurrence(occurrence) do
+    measurements = %{system_time: System.system_time()}
+    metadata = %{occurrence: occurrence}
+    :telemetry.execute([:error_tracker, :new_occurrence], measurements, metadata)
+  end
+end

--- a/lib/error_tracker/telemetry.ex
+++ b/lib/error_tracker/telemetry.ex
@@ -6,24 +6,28 @@ defmodule ErrorTracker.Telemetry do
   @doc false
   def new_error(error) do
     measurements = %{system_time: System.system_time()}
-    :telemetry.execute([:error_tracker, :new_error], measurements, %{error: error})
+    metadata = %{error: error}
+    :telemetry.execute([:error_tracker, :error, :new], measurements, metadata)
   end
 
   @doc false
   def unresolved_error(error) do
     measurements = %{system_time: System.system_time()}
-    :telemetry.execute([:error_tracker, :unresolved_error], measurements, %{error: error})
+    metadata = %{error: error}
+    :telemetry.execute([:error_tracker, :error, :unresolved], measurements, metadata)
   end
 
   @doc false
   def resolved_error(error) do
     measurements = %{system_time: System.system_time()}
-    :telemetry.execute([:error_tracker, :resolved_error], measurements, %{error: error})
+    metadata = %{error: error}
+    :telemetry.execute([:error_tracker, :error, :resolved], measurements, metadata)
   end
 
   @doc false
   def new_occurrence(occurrence) do
     measurements = %{system_time: System.system_time()}
-    :telemetry.execute([:error_tracker, :new_occurrence], measurements, %{occurrence: occurrence})
+    metadata = %{occurrence: occurrence}
+    :telemetry.execute([:error_tracker, :occurrence, :new], measurements, metadata)
   end
 end

--- a/lib/error_tracker/telemetry.ex
+++ b/lib/error_tracker/telemetry.ex
@@ -18,7 +18,7 @@ defmodule ErrorTracker.Telemetry do
   @doc false
   def resolved_error(error) do
     measurements = %{system_time: System.system_time()}
-    :telemetry.execute([:error_tracker, :unresolved_error], measurements, %{error: error})
+    :telemetry.execute([:error_tracker, :resolved_error], measurements, %{error: error})
   end
 
   @doc false

--- a/lib/error_tracker/telemetry.ex
+++ b/lib/error_tracker/telemetry.ex
@@ -5,9 +5,6 @@ defmodule ErrorTracker.Telemetry do
   ErrorTracker emits some events to allow third parties to receive information
   of errors and occurrences stored.
 
-  We emit four type of events which allows to track the lifetime of errors of
-  your application.
-
   ### Error events
 
   Those occur during the lifetime of an error:


### PR DESCRIPTION
This change adds four telemetry events to allow third parties to attach to events regarding the life cycle of Events and Occurrences.

It currently emits events when:
- A new error is recorded
- An error is marked as resolved
- An error is marked as unresolved
- An occurrence is stored

Documentation has been updated.

Tests are not there yet because we are actively working in setting up the test suite in #34 