### PR TITLE
Ensure migration_timestamp is a varchar

### DIFF
--- a/lib/error_tracker/migration/sql_migrator.ex
+++ b/lib/error_tracker/migration/sql_migrator.ex
@@ -69,14 +69,14 @@ defmodule ErrorTracker.Migration.SQLMigrator do
 
         execute """
         INSERT INTO #{prefix}.error_tracker_meta (key, value)
-        VALUES ('migration_version', '#{version}'), ('migration_timestamp', #{timestamp})
+        VALUES ('migration_version', '#{version}'), ('migration_timestamp', '#{timestamp}')
         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
         """
 
       _other ->
         execute """
         INSERT INTO error_tracker_meta (key, value)
-        VALUES ('migration_version', '#{version}'), ('migration_timestamp', #{timestamp})
+        VALUES ('migration_version', '#{version}'), ('migration_timestamp', '#{timestamp}')
         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
         """
     end


### PR DESCRIPTION
The `error_tracker_meta` table defines both `key` and `value` as `varchar(255)`. When inserting the `migration_timestamp` we were sending an integer, which was implicitly converted to a varchar in PostgreSQL but not in other PostgreSQL-compatible databases such as CockroachDB.

This change ensures that the `migration_timestamp` is sent to the DB with the right type and doesn't depend on implicit type conversions.

Fixes #43

---

To test this I set up a Cockroach DB [using Docker](https://www.cockroachlabs.com/docs/stable/start-a-local-cluster-in-docker-linux.html#start-a-single-node-cluster) and then connected my local ErrorTracker instance to it. It failed right away when running the migrations.