### PR TITLE
Use CSP nonces for script and style tags

### DIFF
--- a/lib/error_tracker/web/components/layouts/root.html.heex
+++ b/lib/error_tracker/web/components/layouts/root.html.heex
@@ -10,10 +10,10 @@
 
     <title><%= assigns[:page_title] || "🐛 ErrorTracker" %></title>
 
-    <style>
+    <style nonce={@csp_nonces[:style]}>
       <%= raw get_content(:css) %>
     </style>
-    <script>
+    <script nonce={@csp_nonces[:script]}>
       <%= raw get_content(:js) %>
     </script>
   </head>

--- a/lib/error_tracker/web/hooks/set_assigns.ex
+++ b/lib/error_tracker/web/hooks/set_assigns.ex
@@ -1,7 +1,11 @@
 defmodule ErrorTracker.Web.Hooks.SetAssigns do
   @moduledoc false
 
-  def on_mount({:set_dashboard_path, path}, _params, _session, socket) do
-    {:cont, %{socket | private: Map.put(socket.private, :dashboard_path, path)}}
+  import Phoenix.Component, only: [assign: 2]
+
+  def on_mount({:set_dashboard_path, path}, _params, session, socket) do
+    socket = %{socket | private: Map.put(socket.private, :dashboard_path, path)}
+
+    {:cont, assign(socket, csp_nonces: session["csp_nonces"])}
   end
 end

--- a/lib/error_tracker/web/router.ex
+++ b/lib/error_tracker/web/router.ex
@@ -12,9 +12,9 @@ defmodule ErrorTracker.Web.Router do
 
   ## Security considerations
 
-  Errors may contain sensitive information so it is recommended to use the `on_mount`
-  option to provide a custom hook that implements authentication and authorization
-  for access control.
+  The dashboard inlines both the JS and CSS assets. This means that, if your
+  application has a Content Security Policy, you need to specify the
+  `csp_nonce_assign_key` option, which is explained below.
 
   ## Options
 
@@ -23,6 +23,10 @@ defmodule ErrorTracker.Web.Router do
 
   * `as`: a session name to use for the dashboard LiveView session. By default
   it uses `:error_tracker_dashboard`.
+
+  * `csp_nonce_assign_key`: an assign key to find the CSP nonce value used for assets.
+  Supports either `atom()` or a map of type
+  `%{optional(:img) => atom(), optional(:script) => atom(), optional(:style) => atom()}`
   """
   defmacro error_tracker_dashboard(path, opts \\ []) do
     quote bind_quoted: [path: path, opts: opts] do


### PR DESCRIPTION
This pull request adds a new `:csp_nonce_assign_key` option to the `error_tracker_dashboard/2` macro. If provided, the error tracker will fetch the nonce from the given assign key and use it in the `<style>` and `<script>` tags.

This allows using the ErrorTracker dashboard in environments with a restricted content security policy without requiring the usage of `unsafe-inline`, which should be avoided.

This implementation is based on the [Phoenix LiveDashboard](https://hexdocs.pm/phoenix_live_dashboard/Phoenix.LiveDashboard.Router.html#live_dashboard/2) one.

I've updated the `dev.exs` script to use CSP headers. If we remove the new option we will see that the ErrorTracker dashboard doesn't have any styles.

Closes #58