### PR TITLE
Use explicit column name for FK references

### DIFF
--- a/lib/error_tracker/migration/postgres/v01.ex
+++ b/lib/error_tracker/migration/postgres/v01.ex
@@ -48,7 +48,11 @@ defmodule ErrorTracker.Migration.Postgres.V01 do
         add :stacktrace, :map, null: false
 
         add :error_id,
-            references(:error_tracker_errors, on_delete: :delete_all, type: :bigserial),
+            references(:error_tracker_errors,
+              on_delete: :delete_all,
+              column: :id,
+              type: :bigserial
+            ),
             null: false
 
         timestamps(type: :utc_datetime_usec, updated_at: false)

--- a/lib/error_tracker/migration/sqlite/v02.ex
+++ b/lib/error_tracker/migration/sqlite/v02.ex
@@ -27,8 +27,9 @@ defmodule ErrorTracker.Migration.SQLite.V02 do
       add :reason, :text, null: false
       add :stacktrace, :map, null: false
 
-      add :error_id, references(:error_tracker_errors, on_delete: :delete_all, type: :bigserial),
-        null: false
+      add :error_id,
+          references(:error_tracker_errors, on_delete: :delete_all, column: :id, type: :bigserial),
+          null: false
 
       timestamps(type: :utc_datetime_usec, updated_at: false)
     end


### PR DESCRIPTION
The ErrorTracker tables use `id` as the primary key name. This was causing trouble when the client repository was configured to use a different column name for references since it tried to create a foreign key pointing to a non-existing column.

This commit explicitly states the referenced column name to avoid this problems.

To check this you can create a new Phoenix application that uses the error tracker and add the following configuration to the application repository:

```elixir
config :my_app, MyApp.Repo,
  migration_primary_key: [name: :uuid, type: :binary_id],
  migration_foreign_key: [column: :uuid, type: :binary_id]
```

Trying this on `main` will raise an error when running the migrations. The error is not present in this branch.

Closes #59 