### PR TITLE
Do not store error if context/occurrence is not valid

### DIFF
--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -106,6 +106,8 @@ The `ErrorTracker.set_context/1` function stores the given context in the curren
 ErrorTracker.set_context(%{user_id: conn.assigns.current_user.id})
 ```
 
+There are some requirements on the type of data that can be included in the context, so we recommend taking a look at `set_context/1` documentation
+
 ## Manual error tracking
 
 If you want to report custom errors that fall outside the default integration scope, you may use `ErrorTracker.report/2`. This allows you to report an exception yourself:

--- a/lib/error_tracker.ex
+++ b/lib/error_tracker.ex
@@ -41,6 +41,9 @@ defmodule ErrorTracker do
   can gather, but aside from that, you can also add your own information. You can
   do this in a per-process basis or in a per-call basis (or both).
 
+  There are some requirements on the type of data that can be included in the
+  context, so we recommend taking a look at `set_context/1` documentation.
+
   **Per process**
 
   This allows you to set a general context for the current process such as a Phoenix
@@ -152,6 +155,17 @@ defmodule ErrorTracker do
 
   That means that any existing data on deep levels for he current context will
   be replaced if the first level key is received on the new contents.
+
+  ## Content serialization
+
+  The content stored on the context should be serializable using the JSON library
+  used by the application (usually `Jason`), so it is rather recommended to use
+  primitive types (strings, numbers, booleans...).
+
+  If you still need to pass more complex data types to your context, please test
+  that they can be encoded to JSON or storing the errors will fail. In the case
+  of `Jason` that may require defining an Encoder for that data type if not
+  included by default.
   """
   @spec set_context(context()) :: context()
   def set_context(params) when is_map(params) do

--- a/lib/error_tracker/repo.ex
+++ b/lib/error_tracker/repo.ex
@@ -29,6 +29,10 @@ defmodule ErrorTracker.Repo do
     dispatch(:aggregate, [queryable, aggregate], opts)
   end
 
+  def transaction(fun_or_multi, opts \\ []) do
+    dispatch(:transaction, [fun_or_multi], opts)
+  end
+
   def with_adapter(fun) do
     adapter =
       case repo().__adapter__() do


### PR DESCRIPTION
This change solves an issue in which an invalida content of the error context 
case the `Error` schema to be stored but not the `Occurrence`, which means that 
the error appears on the dashboard list but cannot be opened because the details 
were not stored.

On this change I change the store procedure to use a DB transaction and ensure 
that, if something fails, no data is stored and an exception is generated.

I thought about storing that exception ourselves but if the issue is not related 
to the data stored but other parts of the stack (network, DB, etc) it can end up 
in an infinite loop.

I have also updated the documentation so it states the requirements needed for 
the context data to be stored (basically, it has to be convertible to JSON).

Closes #65 