### PR TITLE
Update install guides migration example

### DIFF
--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -53,8 +53,15 @@ Open the generated migration and call the `up` and `down` functions on `ErrorTra
 defmodule MyApp.Repo.Migrations.AddErrorTracker do
   use Ecto.Migration
 
-  def up, do: ErrorTracker.Migration.up()
-  def down, do: ErrorTracker.Migration.down()
+  def up do
+    ErrorTracker.Migration.up(version: 2)
+  end
+
+  # We specify `version: 1` in `down`, ensuring that we'll roll all the way back down if
+  # necessary, regardless of which version we've migrated `up` to.
+  def down do
+    ErrorTracker.Migration.down(version: 1)
+  end
 end
 ```
 

--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -53,15 +53,10 @@ Open the generated migration and call the `up` and `down` functions on `ErrorTra
 defmodule MyApp.Repo.Migrations.AddErrorTracker do
   use Ecto.Migration
 
-  def up do
-    ErrorTracker.Migration.up(version: 2)
-  end
+  def up, do: ErrorTracker.Migration.up(version: 2)
 
-  # We specify `version: 1` in `down`, ensuring that we'll roll all the way back down if
-  # necessary, regardless of which version we've migrated `up` to.
-  def down do
-    ErrorTracker.Migration.down(version: 1)
-  end
+  # We specify `version: 1` in `down`, to ensure we remove all migrations.
+  def down, do: ErrorTracker.Migration.down(version: 1)
 end
 ```
 


### PR DESCRIPTION
As it may be seen in [Oban](https://hexdocs.pm/oban/installation.html) it is recommended to set up hard version on the initial migration, so we can ensure the ErrorTracker database matches the same schema over time.

This is important because other migrations may use our schema and if we do not specify it we may end up with the latest schema update (version 10 for example) when the next migration was expecting version 2.