### PR TITLE
Prune resolved errors

### DIFF
--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -138,3 +138,11 @@ We currently do not support notifications out of the box.
 However, we provideo some detailed Telemetry events that you may use to implement your own notifications following your custom rules and notification channels.
 
 If you want to take a look at the events you can attach to, take a look at `ErrorTracker.Telemetry` module documentation.
+
+## Pruning resolved errors
+
+By default errors are kept in the database indefinitely. This is not ideal for production
+environments where you may want to prune old errors that have been resolved.
+
+The `ErrorTracker.Plugins.Pruner` module provides automatic pruning functionality with a configurable
+interval and error age.

--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -53,7 +53,7 @@ Open the generated migration and call the `up` and `down` functions on `ErrorTra
 defmodule MyApp.Repo.Migrations.AddErrorTracker do
   use Ecto.Migration
 
-  def up, do: ErrorTracker.Migration.up(version: 2)
+  def up, do: ErrorTracker.Migration.up(version: 3)
 
   # We specify `version: 1` in `down`, to ensure we remove all migrations.
   def down, do: ErrorTracker.Migration.down(version: 1)

--- a/lib/error_tracker/application.ex
+++ b/lib/error_tracker/application.ex
@@ -4,7 +4,7 @@ defmodule ErrorTracker.Application do
   use Application
 
   def start(_type, _args) do
-    children = []
+    children = Application.get_env(:error_tracker, :plugins, [])
 
     attach_handlers()
 

--- a/lib/error_tracker/migration/postgres.ex
+++ b/lib/error_tracker/migration/postgres.ex
@@ -7,7 +7,7 @@ defmodule ErrorTracker.Migration.Postgres do
   alias ErrorTracker.Migration.SQLMigrator
 
   @initial_version 1
-  @current_version 2
+  @current_version 3
   @default_prefix "public"
 
   @impl ErrorTracker.Migration

--- a/lib/error_tracker/migration/postgres/v03.ex
+++ b/lib/error_tracker/migration/postgres/v03.ex
@@ -1,0 +1,13 @@
+defmodule ErrorTracker.Migration.Postgres.V03 do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def up(%{prefix: prefix}) do
+    create_if_not_exists index(:error_tracker_errors, [:last_occurrence_at], prefix: prefix)
+  end
+
+  def down(%{prefix: prefix}) do
+    drop_if_exists index(:error_tracker_errors, [:last_occurrence_at], prefix: prefix)
+  end
+end

--- a/lib/error_tracker/migration/sqlite.ex
+++ b/lib/error_tracker/migration/sqlite.ex
@@ -7,7 +7,7 @@ defmodule ErrorTracker.Migration.SQLite do
   alias ErrorTracker.Migration.SQLMigrator
 
   @initial_version 2
-  @current_version 2
+  @current_version 3
 
   @impl ErrorTracker.Migration
   def up(opts) do

--- a/lib/error_tracker/migration/sqlite/v03.ex
+++ b/lib/error_tracker/migration/sqlite/v03.ex
@@ -1,0 +1,13 @@
+defmodule ErrorTracker.Migration.SQLite.V03 do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def up(_opts) do
+    create_if_not_exists index(:error_tracker_errors, [:last_occurrence_at])
+  end
+
+  def down(_opts) do
+    drop_if_exists index(:error_tracker_errors, [:last_occurrence_at])
+  end
+end

--- a/lib/error_tracker/plugins/pruner.ex
+++ b/lib/error_tracker/plugins/pruner.ex
@@ -86,12 +86,12 @@ defmodule ErrorTracker.Plugins.Pruner do
       )
 
     if Enum.any?(errors) do
-      :ok =
+      _pruned_occurrences_count =
         errors
         |> Ecto.assoc(:occurrences)
         |> limit(1000)
         |> prune_occurrences()
-        |> Stream.run()
+        |> Enum.sum()
 
       Repo.delete_all(from error in Error, where: error.id in ^Enum.map(errors, & &1.id))
     end

--- a/lib/error_tracker/plugins/pruner.ex
+++ b/lib/error_tracker/plugins/pruner.ex
@@ -21,10 +21,10 @@ defmodule ErrorTracker.Plugins.Pruner do
   ## Options
 
   - `:limit`  - the maximum number of errors to prune on each execution. Occurrences are removed
-    along the errors. The default is 1000 to prevent timeouts and unnecesary database load.
+    along the errors. The default is 200 to prevent timeouts and unnecesary database load.
 
-  - `:max_age` - the number of milliseconds after a resolved error may be pruned. The default is 5
-    minutes.
+  - `:max_age` - the number of milliseconds after a resolved error may be pruned. The default is 24
+    hours.
 
   - `:interval` - the interval in milliseconds between pruning runs. The default is 30 minutes.
 
@@ -71,10 +71,10 @@ defmodule ErrorTracker.Plugins.Pruner do
   ## Options
 
   - `:limit`  - the maximum number of errors to prune on each execution. Occurrences are removed
-    along the errors. The default is 1000 to prevent timeouts and unnecesary database load.
+    along the errors. The default is 200 to prevent timeouts and unnecesary database load.
 
-  - `:max_age` - the number of milliseconds after a resolved error may be pruned. The default is 5
-    minutes. You may find the `:timer` module functions useful to pass readable values to this option.
+  - `:max_age` - the number of milliseconds after a resolved error may be pruned. The default is 24
+    hours. You may find the `:timer` module functions useful to pass readable values to this option.
   """
   @spec prune_errors(keyword()) :: {:ok, list(pruned_error())}
   def prune_errors(opts \\ []) do
@@ -106,8 +106,8 @@ defmodule ErrorTracker.Plugins.Pruner do
   @doc false
   def init(state \\ []) do
     state = %{
-      limit: state[:limit] || 1000,
-      max_age: state[:max_age] || :timer.minutes(5),
+      limit: state[:limit] || 200,
+      max_age: state[:max_age] || :timer.hours(24),
       interval: state[:interval] || :timer.minutes(30)
     }
 

--- a/lib/error_tracker/plugins/pruner.ex
+++ b/lib/error_tracker/plugins/pruner.ex
@@ -89,7 +89,6 @@ defmodule ErrorTracker.Plugins.Pruner do
       _pruned_occurrences_count =
         errors
         |> Ecto.assoc(:occurrences)
-        |> limit(1000)
         |> prune_occurrences()
         |> Enum.sum()
 
@@ -101,7 +100,8 @@ defmodule ErrorTracker.Plugins.Pruner do
 
   defp prune_occurrences(occurrences_query) do
     Stream.unfold(occurrences_query, fn occurrences_query ->
-      occurrences_ids = Repo.all(from occurrence in occurrences_query, select: occurrence.id)
+      occurrences_ids =
+        Repo.all(from occurrence in occurrences_query, select: occurrence.id, limit: 1000)
 
       case Repo.delete_all(from o in Occurrence, where: o.id in ^occurrences_ids) do
         {0, _} -> nil

--- a/lib/error_tracker/plugins/pruner.ex
+++ b/lib/error_tracker/plugins/pruner.ex
@@ -74,7 +74,7 @@ defmodule ErrorTracker.Plugins.Pruner do
   def prune_errors(opts \\ []) do
     limit = opts[:limit] || raise ":limit option is required"
     max_age = opts[:max_age] || raise ":max_age option is required"
-    time = DateTime.add(DateTime.utc_now(), max_age, :millisecond)
+    time = DateTime.add(DateTime.utc_now(), -max_age, :millisecond)
 
     errors =
       Repo.all(

--- a/lib/error_tracker/plugins/pruner.ex
+++ b/lib/error_tracker/plugins/pruner.ex
@@ -1,0 +1,122 @@
+defmodule ErrorTracker.Plugins.Pruner do
+  @moduledoc """
+  Periodically delete resolved errors based on their age.
+
+  Pruning allows you to keep your database size under control by removing old errors that are not
+  needed anymore.
+
+  ## Using the pruner
+
+  To enable the pruner you must register the plugin in the ErrorTracker configuration. This will use
+  the default options, which is to prune errors resolved after 5 minutes.
+
+      config :error_tracker,
+        plugins: [ErrorTracker.Plugins.Pruner]
+
+  You can override the default options by passing them as an argument when registering the plugin.
+
+      config :error_tracker,
+        plugins: [{ErrorTracker.Plugins.Pruner, max_age: :timer.minutes(30)}]
+
+  ## Options
+
+  - `:limit`  - the maximum number of errors to prune on each execution. Occurrences are removed
+    along the errors. The default is 1000 to prevent timeouts and unnecesary database load.
+
+  - `:max_age` - the number of milliseconds after a resolved error may be pruned. The default is 5
+    minutes.
+
+  - `:interval` - the interval in milliseconds between pruning runs. The default is 30 minutes.
+
+  You may find the `:timer` module functions useful to pass readable values to the `:max_age` and
+  `:interval` options.
+
+  ## Manual pruning
+
+  In certain cases you may prefer to run the pruner manually. This can be done by calling the
+  `prune_errors/2` function from your application code. This function supports the `:limit` and
+  `:max_age` options as described above.
+
+  For example, you may call this function from an Oban worker so you can leverage Oban's cron
+  capabilities and have a more granular control over when pruning is run.
+
+      defmodule MyApp.ErrorPruner do
+        use Oban.Job
+
+        def perform(%Job{}) do
+          ErrorTracker.Plugins.Pruner.prune_errors(limit: 10_000, max_age: :timer.minutes(60))
+        end
+      end
+  """
+  use GenServer
+
+  import Ecto.Query
+
+  alias ErrorTracker.Error
+  alias ErrorTracker.Repo
+
+  @type pruned_error :: %{
+          id: :integer,
+          kind: String.t(),
+          source_line: String.t(),
+          source_function: String.t()
+        }
+
+  @doc """
+  Prunes resolved errors.
+
+  You do not need to use this function if you activate the Pruner plugin. This function is exposed
+  only for advanced use cases and Oban integration.
+
+  ## Options
+
+  - `:limit`  - the maximum number of errors to prune on each execution. Occurrences are removed
+    along the errors. The default is 1000 to prevent timeouts and unnecesary database load.
+
+  - `:max_age` - the number of milliseconds after a resolved error may be pruned. The default is 5
+    minutes. You may find the `:timer` module functions useful to pass readable values to this option.
+  """
+  @spec prune_errors(keyword()) :: {:ok, list(pruned_error())}
+  def prune_errors(opts \\ []) do
+    limit = opts[:limit] || 1000
+    max_age = opts[:max_age] || :timer.minutes(5)
+    time = DateTime.add(DateTime.utc_now(), max_age, :millisecond)
+
+    to_prune_query =
+      from error in Error,
+        select: map(error, [:id, :kind, :source_line, :source_function]),
+        where: error.status == :resolved,
+        where: error.last_occurrence_at >= ^time,
+        limit: ^limit
+
+    {_count, pruned} = Repo.delete_all(to_prune_query)
+
+    {:ok, pruned}
+  end
+
+  @impl GenServer
+  @doc false
+  def init(state) do
+    state = %{
+      limit: state[:limit] || 1000,
+      max_age: state[:max_age] || :timer.minutes(5),
+      interval: state[:interval] || :timer.minutes(30)
+    }
+
+    {:ok, schedule_prune(state)}
+  end
+
+  @impl GenServer
+  @doc false
+  def handle_info(:prune, state) do
+    {:ok, _pruned} = prune_errors(state)
+
+    {:noreply, schedule_prune(state)}
+  end
+
+  defp schedule_prune(state = %{interval: interval}) do
+    Process.send_after(self(), :prune, interval)
+
+    state
+  end
+end

--- a/lib/error_tracker/repo.ex
+++ b/lib/error_tracker/repo.ex
@@ -25,6 +25,10 @@ defmodule ErrorTracker.Repo do
     dispatch(:all, [queryable], opts)
   end
 
+  def delete_all(queryable, opts \\ []) do
+    dispatch(:delete_all, [queryable], opts)
+  end
+
   def aggregate(queryable, aggregate, opts \\ []) do
     dispatch(:aggregate, [queryable, aggregate], opts)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -65,6 +65,9 @@ defmodule ErrorTracker.MixProject do
         ErrorTracker.Integrations.Phoenix,
         ErrorTracker.Integrations.Plug
       ],
+      Plugins: [
+        ErrorTracker.Plugins.Pruner
+      ],
       Schemas: [
         ErrorTracker.Error,
         ErrorTracker.Occurrence,

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,0 +1,45 @@
+adapter =
+  case Application.get_env(:error_tracker, :ecto_adapter) do
+    :postgres -> Ecto.Adapters.Postgres
+    :sqlite3 -> Ecto.Adapters.SQLite3
+  end
+
+defmodule ErrorTrackerDev.Repo do
+  use Ecto.Repo, otp_app: :error_tracker, adapter: adapter
+end
+
+ErrorTrackerDev.Repo.start_link()
+
+ErrorTrackerDev.Repo.delete_all(ErrorTracker.Error)
+
+errors =
+  for i <- 1..100 do
+    %{
+      kind: "Error #{i}",
+      reason: "Reason #{i}",
+      source_line: "line",
+      source_function: "function",
+      status: :unresolved,
+      fingerprint: "#{i}",
+      last_occurrence_at: DateTime.utc_now(),
+      inserted_at: DateTime.utc_now(),
+      updated_at: DateTime.utc_now()
+    }
+  end
+
+{_, errors} = dbg(ErrorTrackerDev.Repo.insert_all(ErrorTracker.Error, errors, returning: [:id]))
+
+for error <- errors do
+  occurrences =
+    for _i <- 1..200 do
+      %{
+        context: %{},
+        reason: "REASON",
+        stacktrace: %ErrorTracker.Stacktrace{},
+        error_id: error.id,
+        inserted_at: DateTime.utc_now()
+      }
+    end
+
+  ErrorTrackerDev.Repo.insert_all(ErrorTracker.Occurrence, occurrences)
+end


### PR DESCRIPTION
This pull request adds a new `ErrorTracker.Plugins.Pruner` which automatically prunes resolved errors. This plugin can be used automatically or manually.

ℹ️ I've also added a new priv/repo/seeds.exs script that populates the db with some fake errors and occurrences. May be useful for testing the dashboard, pruning and other features easily.

## Automatic use

Register the plugin under the ErrorTracker configuration. The pruner will run in the background every 30 minutes and remove up to 1000 resolved errors older than 5 minutes (this options can be overriden)

```elixir
config :error_tracker,
  repo: MyApp.Repo,
  otp_app: :my_app,
  plugins: [ErrorTracker.Plugins.Pruner]
```

## Manual use

If you want to have more fine-grained control over when the pruner runs you can use the `ErrorTracker.Plugins.Pruner.prune_errors/1` function. In this case you must pass the `:limit` and `:max_age` options explicitly.

You may want to call this function from an Oban job to leverage its cron-like capabilities.

```elixir
defmodule MyApp.ErrorPruner do
  use Oban.Job

  def perform(%Job{}) do
    ErrorTracker.Plugins.Pruner.prune_errors(limit: 10_000, max_age: :timer.minutes(60))
  end
end
```

Closes #64 