### PR TITLE
Fix reporting errors from Oban

### DIFF
--- a/lib/error_tracker/integrations/oban.ex
+++ b/lib/error_tracker/integrations/oban.ex
@@ -59,7 +59,8 @@ defmodule ErrorTracker.Integrations.Oban do
 
   def handle_event([:oban, :job, :exception], _measurements, metadata, :no_config) do
     %{reason: exception, stacktrace: stacktrace} = metadata
+    state = Map.get(metadata, :state, :failure)
 
-    ErrorTracker.report(exception, stacktrace)
+    ErrorTracker.report(exception, stacktrace, %{state: state})
   end
 end

--- a/lib/error_tracker/schemas/error.ex
+++ b/lib/error_tracker/schemas/error.ex
@@ -29,12 +29,21 @@ defmodule ErrorTracker.Error do
   @doc false
   def new(kind, reason, stacktrace = %ErrorTracker.Stacktrace{}) do
     source = ErrorTracker.Stacktrace.source(stacktrace)
-    source_line = if source.file, do: "#{source.file}:#{source.line}", else: "nofile"
+
+    {source_line, source_function} =
+      if source do
+        source_line = if source.line, do: "#{source.file}:#{source.line}", else: "nofile"
+        source_function = "#{source.module}.#{source.function}/#{source.arity}"
+
+        {source_line, source_function}
+      else
+        {"-", "-"}
+      end
 
     params = [
       kind: to_string(kind),
       source_line: source_line,
-      source_function: "#{source.module}.#{source.function}/#{source.arity}"
+      source_function: source_function
     ]
 
     fingerprint = :crypto.hash(:sha256, params |> Keyword.values() |> Enum.join())

--- a/lib/error_tracker/schemas/error.ex
+++ b/lib/error_tracker/schemas/error.ex
@@ -55,4 +55,14 @@ defmodule ErrorTracker.Error do
     |> Ecto.Changeset.put_change(:last_occurrence_at, DateTime.utc_now())
     |> Ecto.Changeset.apply_action(:new)
   end
+
+  @doc """
+  Returns if the Error has information of the source or not.
+
+  Errors usually have information about in which line and function occurred, but
+  in some cases (like an Oban job ending with `{:error, any()}`) we cannot get
+  that information and no source is stored.
+  """
+  def has_source_info?(%__MODULE__{source_function: "-", source_line: "-"}), do: false
+  def has_source_info?(%__MODULE__{}), do: true
 end

--- a/lib/error_tracker/web/live/dashboard.html.heex
+++ b/lib/error_tracker/web/live/dashboard.html.heex
@@ -69,10 +69,9 @@
           <p class="whitespace-nowrap text-ellipsis w-full overflow-hidden">
             (<%= sanitize_module(error.kind) %>) <%= error.reason %>
           </p>
-          <p :if={error.source_function != "-"} class="font-normal text-gray-400">
+          <p :if={ErrorTracker.Error.has_source_info?(error)} class="font-normal text-gray-400">
             <%= sanitize_module(error.source_function) %>
-          </p>
-          <p :if={error.source_function != "-"} class="font-normal text-gray-400">
+            <br />
             <%= error.source_line %>
           </p>
         </td>

--- a/lib/error_tracker/web/live/dashboard.html.heex
+++ b/lib/error_tracker/web/live/dashboard.html.heex
@@ -69,9 +69,10 @@
           <p class="whitespace-nowrap text-ellipsis w-full overflow-hidden">
             (<%= sanitize_module(error.kind) %>) <%= error.reason %>
           </p>
-          <p class="font-normal text-gray-400">
+          <p :if={error.source_function != "-"} class="font-normal text-gray-400">
             <%= sanitize_module(error.source_function) %>
-            <br />
+          </p>
+          <p :if={error.source_function != "-"} class="font-normal text-gray-400">
             <%= error.source_line %>
           </p>
         </td>

--- a/lib/error_tracker/web/live/show.ex
+++ b/lib/error_tracker/web/live/show.ex
@@ -121,7 +121,4 @@ defmodule ErrorTracker.Web.Live.Show do
     |> limit(^num_results)
     |> Repo.all()
   end
-
-  defp error_has_source_info?(%Error{source_function: "-", source_line: "-"}), do: false
-  defp error_has_source_info?(%Error{}), do: true
 end

--- a/lib/error_tracker/web/live/show.ex
+++ b/lib/error_tracker/web/live/show.ex
@@ -121,4 +121,7 @@ defmodule ErrorTracker.Web.Live.Show do
     |> limit(^num_results)
     |> Repo.all()
   end
+
+  defp error_has_source_info?(%Error{source_function: "-", source_line: "-"}), do: false
+  defp error_has_source_info?(%Error{}), do: true
 end

--- a/lib/error_tracker/web/live/show.html.heex
+++ b/lib/error_tracker/web/live/show.html.heex
@@ -19,7 +19,7 @@
       <pre class="overflow-auto p-4 rounded-lg bg-gray-300/10 border border-gray-900"><%= @occurrence.reason %></pre>
     </.section>
 
-    <.section :if={error_has_source_info?(@error)} title="Source">
+    <.section :if={ErrorTracker.Error.has_source_info?(@error)} title="Source">
       <pre class="overflow-auto text-sm p-4 rounded-lg bg-gray-300/10 border border-gray-900">
         <%= sanitize_module(@error.source_function) %>
         <%= @error.source_line %></pre>

--- a/lib/error_tracker/web/live/show.html.heex
+++ b/lib/error_tracker/web/live/show.html.heex
@@ -19,13 +19,13 @@
       <pre class="overflow-auto p-4 rounded-lg bg-gray-300/10 border border-gray-900"><%= @occurrence.reason %></pre>
     </.section>
 
-    <.section title="Source">
+    <.section :if={error_has_source_info?(@error)} title="Source">
       <pre class="overflow-auto text-sm p-4 rounded-lg bg-gray-300/10 border border-gray-900">
         <%= sanitize_module(@error.source_function) %>
         <%= @error.source_line %></pre>
     </.section>
 
-    <.section title="Stacktrace">
+    <.section :if={@occurrence.stacktrace.lines != []} title="Stacktrace">
       <div class="p-4 bg-gray-300/10 border border-gray-900 rounded-lg">
         <div class="w-full mb-4">
           <label class="flex justify-end">


### PR DESCRIPTION
There was an error when an Oban worker returned an `{:error, reason}` tuple because Oban does not return an stacktrace (makes sense, as it is not an exception by itself).

Our code was not prepared for that use case. I modified it to handle it and circumvent the needed for source file and source function information.

After this change, empty stack traces and source information are not shown on the dashboard to avoid confusion.

As an extra feature I have also added the reporting of the `state` of the job (which is mostly ever `failure` for us).

## How to test

The way to reproduce it is to have an Oban worker which returns a tuple `{:error, any()}` or just `:error`.

That use case generates an exception in the latest release and works as expected on this branch.

---

Closes #63 