### PR TITLE
Add LiveView event to context only during exceptions

### DIFF
--- a/lib/error_tracker/integrations/phoenix.ex
+++ b/lib/error_tracker/integrations/phoenix.ex
@@ -103,8 +103,8 @@ defmodule ErrorTracker.Integrations.Phoenix do
     })
   end
 
-  def handle_event([:phoenix, :live_view, :handle_event, :start], _, metadata, :no_config) do
-    ErrorTracker.set_context(%{
+  def handle_event([:phoenix, :live_view, :handle_event, :exception], _, metadata, :no_config) do
+    ErrorTracker.report({metadata.kind, metadata.reason}, metadata.stacktrace, %{
       "live_view.event" => metadata.event,
       "live_view.event_params" => metadata.params
     })

--- a/lib/error_tracker/integrations/phoenix.ex
+++ b/lib/error_tracker/integrations/phoenix.ex
@@ -58,7 +58,6 @@ defmodule ErrorTracker.Integrations.Phoenix do
     [:phoenix, :live_view, :mount, :exception],
     [:phoenix, :live_view, :handle_params, :start],
     [:phoenix, :live_view, :handle_params, :exception],
-    [:phoenix, :live_view, :handle_event, :start],
     [:phoenix, :live_view, :handle_event, :exception],
     [:phoenix, :live_view, :render, :exception],
     [:phoenix, :live_component, :update, :exception],


### PR DESCRIPTION
As @odarriba and @numso discussed on #74 the current approach of adding LiveView event information to the process context may result in misleading information for certain errors.

> For example, if the following happened:
> 
> 1. mount the liveview
> 2. handle_event("something", params, socket) in the liveview
> 3. handle_info("something_else", socket) causing a re-render
> 4. render -> exception occurs
>
> I think live_view.event and live_view.event_params would still be in the error context when the exception was reported. They would have been assigned to context in step 2. But by step 4, that data could be irrelevant. Am I understanding that right?

This pull request adds the LiveView event information to the context only during exceptions and avoids the situations mentioned above. The LiveView name, URL and URL params are still part of the process context as that information is helpful to understand what was going on before the error happened.

This is consistent with the LiveComponent error handled implemented in #74 