### PR TITLE
Flag to globally disable error tracking

### DIFF
--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -32,12 +32,15 @@ ErrorTracker needs a few configuration options to work. This configuration shoul
 ```elixir
 config :error_tracker,
   repo: MyApp.Repo,
-  otp_app: :my_app
+  otp_app: :my_app,
+  enabled: true
 ```
 
 The `:repo` option specifies the repository that will be used by ErrorTracker. You can use your regular application repository or a different one if you prefer to keep errors in a different database.
 
 The `:otp_app` option specifies your application name. When an error occurs, ErrorTracker will use this information to understand which parts of the stack trace belong to your application and which parts belong to third-party dependencies. This allows you to filter in-app vs third-party frames when viewing errors.
+
+The `:enabled` option (defaults to `true` if not present) allows to disable the ErrorTracker on certain environments. This is useful to avoid filling your dev database with errors, for example.
 
 ## Setting up the database
 

--- a/lib/error_tracker.ex
+++ b/lib/error_tracker.ex
@@ -77,6 +77,9 @@ defmodule ErrorTracker do
   @doc """
   Report an exception to be stored.
 
+  Returns the occurrence stored or `:noop` if the ErrorTracker is disabled and the
+  exception has not been stored.
+
   Aside from the exception, it is expected to receive the stack trace and,
   optionally, a context map which will be merged with the current process
   context.
@@ -111,9 +114,12 @@ defmodule ErrorTracker do
 
     context = Map.merge(get_context(), given_context)
 
-    {_error, occurrence} = upsert_error!(error, stacktrace, context, reason)
-
-    occurrence
+    if enabled?() do
+      {_error, occurrence} = upsert_error!(error, stacktrace, context, reason)
+      occurrence
+    else
+      :noop
+    end
   end
 
   @doc """
@@ -183,6 +189,10 @@ defmodule ErrorTracker do
   @spec get_context() :: context()
   def get_context do
     Process.get(:error_tracker_context, %{})
+  end
+
+  defp enabled? do
+    !!Application.get_env(:error_tracker, :enabled, true)
   end
 
   defp normalize_exception(%struct{} = ex, _stacktrace) when is_exception(ex) do

--- a/lib/error_tracker.ex
+++ b/lib/error_tracker.ex
@@ -77,8 +77,8 @@ defmodule ErrorTracker do
   @doc """
   Report an exception to be stored.
 
-  Returns the occurrence stored or `:noop` if the ErrorTracker is disabled and the
-  exception has not been stored.
+  Returns the occurrence stored or `:noop` if the ErrorTracker is disabled by
+  configuration the exception has not been stored.
 
   Aside from the exception, it is expected to receive the stack trace and,
   optionally, a context map which will be merged with the current process

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -28,7 +28,10 @@ defmodule ErrorTracker.Test.Case do
           ErrorTracker.report({kind, reason}, __STACKTRACE__, context)
       end
 
-    repo().preload(occurrence, :error)
+    case occurrence do
+      %ErrorTracker.Occurrence{} -> repo().preload(occurrence, :error)
+      other -> other
+    end
   end
 
   @doc """


### PR DESCRIPTION
This change adds a new global flag named `:enabled` that allows to disable the error tracking on certain environments.

This behaviour can be done also with a custom ignorer using the changes that we will introduce in #79 , but I felt like this use case will be quite common in dev environments and having a fast way to just disable every error is useful.

Test have been added and documentation updated.

It is related to #81 