### PR TITLE
Don't import private function name from router

### DIFF
--- a/lib/error_tracker/web/router.ex
+++ b/lib/error_tracker/web/router.ex
@@ -34,7 +34,7 @@ defmodule ErrorTracker.Web.Router do
       # paths for navigating through the dashboard.
       scoped_path = Phoenix.Router.scoped_path(__MODULE__, path)
       # Generate the session name and session hooks.
-      {session_name, session_opts} = parse_options(opts, scoped_path)
+      {session_name, session_opts} = __parse_options__(opts, scoped_path)
 
       scope path, alias: false, as: false do
         import Phoenix.LiveView.Router, only: [live: 4, live_session: 3]
@@ -49,7 +49,7 @@ defmodule ErrorTracker.Web.Router do
   end
 
   @doc false
-  def parse_options(opts, path) do
+  def __parse_options__(opts, path) do
     custom_on_mount = Keyword.get(opts, :on_mount, [])
     session_name = Keyword.get(opts, :as, :error_tracker_dashboard)
 

--- a/lib/error_tracker/web/router.ex
+++ b/lib/error_tracker/web/router.ex
@@ -34,7 +34,7 @@ defmodule ErrorTracker.Web.Router do
       # paths for navigating through the dashboard.
       scoped_path = Phoenix.Router.scoped_path(__MODULE__, path)
       # Generate the session name and session hooks.
-      {session_name, session_opts} = __parse_options__(opts, scoped_path)
+      {session_name, session_opts} = ErrorTracker.Web.Router.__parse_options__(opts, scoped_path)
 
       scope path, alias: false, as: false do
         import Phoenix.LiveView.Router, only: [live: 4, live_session: 3]


### PR DESCRIPTION
Underscored functions are never imported by default. This should fix #90.

If you import the router on `main` you will see that the `parse_options` function is imported automatically:

```elixir
iex(1)> import ErrorTracker.Web.Router
ErrorTracker.Web.Router
iex(2)> h parse_options
No documentation for ErrorTracker.Web.Router.parse_options was found
```

If you do the same now you will se that the function is not imported and it tries to find it in the Kernel module.

```elixir
iex(1)> import ErrorTracker.Web.Router
ErrorTracker.Web.Router
iex(2)> h __parse_options__/2
No documentation for Kernel.__parse_options__/2 was found
```
