### PR TITLE
WIP: Fix Oban.PerformError grouping

### DIFF
--- a/lib/error_tracker/integrations/oban.ex
+++ b/lib/error_tracker/integrations/oban.ex
@@ -58,8 +58,13 @@ defmodule ErrorTracker.Integrations.Oban do
   end
 
   def handle_event([:oban, :job, :exception], _measurements, metadata, :no_config) do
-    %{reason: exception, stacktrace: stacktrace} = metadata
+    %{reason: exception, stacktrace: stacktrace, job: job} = metadata
     state = Map.get(metadata, :state, :failure)
+
+    stacktrace =
+      if stacktrace == [],
+        do: [{String.to_existing_atom("Elixir." <> job.worker), :perform, 2, []}],
+        else: stacktrace
 
     ErrorTracker.report(exception, stacktrace, %{state: state})
   end

--- a/lib/error_tracker/schemas/error.ex
+++ b/lib/error_tracker/schemas/error.ex
@@ -32,7 +32,7 @@ defmodule ErrorTracker.Error do
 
     {source_line, source_function} =
       if source do
-        source_line = if source.line, do: "#{source.file}:#{source.line}", else: "nofile"
+        source_line = if source.line, do: "#{source.file}:#{source.line}", else: "(nofile)"
         source_function = "#{source.module}.#{source.function}/#{source.arity}"
 
         {source_line, source_function}

--- a/lib/error_tracker/web/live/show.html.heex
+++ b/lib/error_tracker/web/live/show.html.heex
@@ -48,7 +48,7 @@
                 <td class="px-2 align-top"><pre>(<%= line.application || @app %>)</pre></td>
                 <td>
                   <pre><%= "#{sanitize_module(line.module)}.#{line.function}/#{line.arity}" %>
-                <%= if line.line, do: "#{line.file}:#{line.line}", else: "nofile" %></pre>
+                <%= if line.line, do: "#{line.file}:#{line.line}", else: "(nofile)" %></pre>
                 </td>
               </tr>
             </tbody>

--- a/test/error_tracker_test.exs
+++ b/test/error_tracker_test.exs
@@ -40,7 +40,7 @@ defmodule ErrorTrackerTest do
         assert error.source_line =~ @relative_file_path
       else
         assert error.source_function == "erlang.+/2"
-        assert error.source_line == "nofile"
+        assert error.source_line == "(nofile)"
       end
     end
 
@@ -54,7 +54,7 @@ defmodule ErrorTrackerTest do
       assert error.kind == to_string(UndefinedFunctionError)
       assert error.reason =~ "is undefined or private"
       assert error.source_function == Exception.format_mfa(m, f, Enum.count(a))
-      assert error.source_line == "nofile"
+      assert error.source_line == "(nofile)"
     end
 
     test "reports throws" do


### PR DESCRIPTION
This change improves how we store data from `Oban.PerformError` errors.

Those errors don't come from exceptions, as they are delivered via Telemetry when the worker ends up with an `:error` or an `{:error, any()}` tuple.

As they are not exceptions, there is no stack trace, and they were been detected as the same error by our fingerprinting algo.

This changes introduces an fix that adds the worker module as the only stacktrace of the occurrence, so the error can populate the `source_function` attribute and different workers generate different error groupings.

We cannot generate different error groups per different outputs of a worker. In that case, you should use `raise`, that generates a full stack trace and works as expected.

Closes #87 