### PR TITLE
fix docs for `Pruner` default max_age value

### DIFF
--- a/lib/error_tracker/plugins/pruner.ex
+++ b/lib/error_tracker/plugins/pruner.ex
@@ -8,7 +8,7 @@ defmodule ErrorTracker.Plugins.Pruner do
   ## Using the pruner
 
   To enable the pruner you must register the plugin in the ErrorTracker configuration. This will use
-  the default options, which is to prune errors resolved after 5 minutes.
+  the default options, which is to prune errors resolved after 24 hours.
 
       config :error_tracker,
         plugins: [ErrorTracker.Plugins.Pruner]


### PR DESCRIPTION
As far as i understand the code and the text below which also states the default of 24 hours, i think the 5 minutes are wrong.