### PR TITLE
Filter context only when tracking errors

### DIFF
--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -113,7 +113,7 @@ There are some requirements on the type of data that can be included in the cont
 ErrorTracker.set_context(%{user_id: conn.assigns.current_user.id})
 ```
 
-You may also want to sanitize of filter out some information from the context before saving it. To do that you can take a look at the `ErrorTracker.Filter` behaviour.
+You may also want to sanitize or filter out some information from the context before saving it. To do that you can take a look at the `ErrorTracker.Filter` behaviour.
 
 ## Manual error tracking
 

--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -107,11 +107,13 @@ In certain cases, you may want to include some additional information when track
 
 The `ErrorTracker.set_context/1` function stores the given context in the current process so any errors that occur in that process (for example, a Phoenix request or an Oban job) will include this given context along with the default integration context.
 
+There are some requirements on the type of data that can be included in the context, so we recommend taking a look at `ErrorTracker.set_context/1` documentation
+
 ```elixir
 ErrorTracker.set_context(%{user_id: conn.assigns.current_user.id})
 ```
 
-There are some requirements on the type of data that can be included in the context, so we recommend taking a look at `ErrorTracker.set_context/1` documentation
+You may also want to sanitize of filter out some information from the context before saving it. To do that you can take a look at the `ErrorTracker.Filter` behaviour.
 
 ## Manual error tracking
 

--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -111,7 +111,7 @@ The `ErrorTracker.set_context/1` function stores the given context in the curren
 ErrorTracker.set_context(%{user_id: conn.assigns.current_user.id})
 ```
 
-There are some requirements on the type of data that can be included in the context, so we recommend taking a look at `set_context/1` documentation
+There are some requirements on the type of data that can be included in the context, so we recommend taking a look at `ErrorTracker.set_context/1` documentation
 
 ## Manual error tracking
 


### PR DESCRIPTION
Just a few additions to #94:
- We don't need to filter context when not tracking errors
- Mention how to filter context in the Getting Started guide