### PR TITLE
Store Ash bread crumbs in occurrence context

### DIFF
--- a/test/error_tracker_test.exs
+++ b/test/error_tracker_test.exs
@@ -99,6 +99,17 @@ defmodule ErrorTrackerTest do
     test "with enabled flag to false it does not store the exception" do
       assert report_error(fn -> raise "Sample error" end) == :noop
     end
+
+    test "includes bread crumbs in the context if present" do
+      bread_crumbs = ["bread crumb 1", "bread crumb 2"]
+
+      occurrence =
+        report_error(fn ->
+          raise ErrorWithBreadcrumbs, message: "test", bread_crumbs: bread_crumbs
+        end)
+
+      assert occurrence.context["bread_crumbs"] == bread_crumbs
+    end
   end
 
   describe inspect(&ErrorTracker.resolve/1) do
@@ -118,4 +129,8 @@ defmodule ErrorTrackerTest do
       assert {:ok, %Error{status: :unresolved}} = ErrorTracker.unresolve(resolved)
     end
   end
+end
+
+defmodule ErrorWithBreadcrumbs do
+  defexception [:message, :bread_crumbs]
 end


### PR DESCRIPTION
Some frameworks such as Ash include breadcrumbs in their errors. This is provided by the fantastic Splode library ([details](https://bsky.app/profile/zachdaniel.dev/post/3l7qsyil4pg2c)).

This commit updates the ErrorTracker to detect such bread crumbs and include them in the occurrence context. In the future we may want to revisit this and store them in their own field separate from the context.

It is important to note that you don't have to use Ash or Splode to leverage this integration. Breadcrumbs will be automatically extracted from any exception that includes a `bread_crumbs` field.

I've discussed this with @zachdaniel and he kindly integrated the breadcrumbs on Ash main for create and change actions.

To test this you can clone the [Ash Realworld](https://github.com/team-alembic/realworld) example project and update the ash dependency to main with `{:ash, github: "ash-project/ash", override: true}`. Here is a screenshot of how it looks like:

![image](https://github.com/user-attachments/assets/103d99c6-bb43-4c74-8df8-4b210cca3bd9)
