### PR TITLE
Safely convert payloads to strings

### DIFF
--- a/lib/error_tracker.ex
+++ b/lib/error_tracker.ex
@@ -229,12 +229,16 @@ defmodule ErrorTracker do
 
   defp normalize_exception({kind, ex}, stacktrace) do
     case Exception.normalize(kind, ex, stacktrace) do
-      %struct{} = ex ->
-        {to_string(struct), Exception.message(ex)}
-
-      other ->
-        {to_string(kind), to_string(other)}
+      %struct{} = ex -> {to_string(struct), Exception.message(ex)}
+      payload -> {to_string(kind), safe_to_string(payload)}
     end
+  end
+
+  defp safe_to_string(term) do
+    to_string(term)
+  rescue
+    Protocol.UndefinedError ->
+      inspect(term)
   end
 
   defp bread_crumbs(exception) do

--- a/live.exs
+++ b/live.exs
@@ -1,7 +1,6 @@
 Mix.install([
-  {:phoenix_playground,
-   github: "phoenix-playground/phoenix_playground",
-   ref: "ee6da0fc3b141f78b9f967ce71a4fb015c6764a6"},
+  {:phoenix_playground, "~> 0.1.7"},
+  {:postgrex, "~> 0.19.3"},
   {:error_tracker, path: "."}
 ])
 

--- a/live.exs
+++ b/live.exs
@@ -12,6 +12,7 @@ end
 Application.put_env(:error_tracker, :repo, ErrorTrackerDev.Repo)
 Application.put_env(:error_tracker, :application, :error_tracker_dev)
 Application.put_env(:error_tracker, :prefix, "private")
+Application.put_env(:error_tracker, :otp_app, :error_tracker_dev)
 
 Application.put_env(:error_tracker, ErrorTrackerDev.Repo,
   url: "ecto://postgres:postgres@127.0.0.1/error_tracker_dev"


### PR DESCRIPTION
For non-error tuples `Exception.normalize/3` returns the original payload, which may be anything. Some payloads such as tuples don't implement the `String.Chars` protocol. So calling `to_string/1` will fail. In such cases we fall back to `inspect/1`.

I made a few updates to the `live.exs` script to reproduce this problem. You can run `elixir live.exs` and click the button called «GenServer timeout». This will cause an error that should be recorded by the error tracker.

If you revert the changes that I made and try this same button you will se that the error payload cannot be converted to string and detaches the ErrorTracker telemetry handler.

Closes #109 