### PR TITLE
Support Elixir 1.18

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -24,6 +24,8 @@ jobs:
             erlang: "24.x"
           - elixir: "1.17.x"
             erlang: "27.x"
+          - elixir: "1.18.x"
+            erlang: "27.x"
     services:
       db:
         image: postgres:15

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -18,12 +18,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - elixir: 1.15.0
-            erlang: 24.0.0
-          - elixir: 1.16.0
-            erlang: 24.0.0
-          - elixir: 1.17.0
-            erlang: 27.0.0
+          - elixir: "1.15.x"
+            erlang: "24.x"
+          - elixir: "1.16.x"
+            erlang: "24.x"
+          - elixir: "1.17.x"
+            erlang: "27.x"
     services:
       db:
         image: postgres:15

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.17
+elixir 1.18
 erlang 27.0


### PR DESCRIPTION
Updates the `.tool-versions` file to use Elixir 1.18 for dev and also updates the build matrix to test against Elixir 1.18 on the CI.