### PR TITLE
Accept prefix option for PostgreSQL v04 migration

### DIFF
--- a/lib/error_tracker/migration/postgres/v04.ex
+++ b/lib/error_tracker/migration/postgres/v04.ex
@@ -3,14 +3,14 @@ defmodule ErrorTracker.Migration.Postgres.V04 do
 
   use Ecto.Migration
 
-  def up(_opts) do
-    alter table(:error_tracker_occurrences) do
+  def up(%{prefix: prefix}) do
+    alter table(:error_tracker_occurrences, prefix: prefix) do
       add :breadcrumbs, {:array, :string}, default: [], null: false
     end
   end
 
-  def down(_opts) do
-    alter table(:error_tracker_occurrences) do
+  def down(%{prefix: prefix}) do
+    alter table(:error_tracker_occurrences, prefix: prefix) do
       remove :breadcrumbs
     end
   end


### PR DESCRIPTION
The latest migration for PostgreSQL ignores the `prefix` option, causing the migration to fail when previous migrations were not using the `public` schema. This PR adds the `prefix` option to the `v04` migration.