### PR TITLE
Fix warning for negative range

### DIFF
--- a/lib/error_tracker/migration/sql_migrator.ex
+++ b/lib/error_tracker/migration/sql_migrator.ex
@@ -24,7 +24,7 @@ defmodule ErrorTracker.Migration.SQLMigrator do
     initial = max(current_version(opts), initial_version)
 
     if initial >= opts.version do
-      change(migrator, initial..opts.version, :down, opts)
+      change(migrator, initial..opts.version//-1, :down, opts)
     end
   end
 


### PR DESCRIPTION
Thank you for this amazing library.

Quick fix for the following warning
```
warning: Range.new/2 and first..last default to a step of -1 when last < first. Use Range.new(first, last, -1) or first..last//-1, or pass 1 if that was your intention
```

This happens when rolling back the migrations (dev) or when removing `error_tracker` (prod)