### PR TITLE
Mute error occurrences

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -4,7 +4,7 @@
 #
 Mix.install([
   {:ecto_sqlite3, ">= 0.0.0"},
-  {:error_tracker, path: "."},
+  {:error_tracker, path: ".", force: true},
   {:phoenix_playground, "~> 0.1.7"}
 ])
 

--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -56,7 +56,7 @@ Open the generated migration and call the `up` and `down` functions on `ErrorTra
 defmodule MyApp.Repo.Migrations.AddErrorTracker do
   use Ecto.Migration
 
-  def up, do: ErrorTracker.Migration.up(version: 4)
+  def up, do: ErrorTracker.Migration.up(version: 5)
 
   # We specify `version: 1` in `down`, to ensure we remove all migrations.
   def down, do: ErrorTracker.Migration.down(version: 1)
@@ -152,9 +152,27 @@ environments where you may want to prune old errors that have been resolved.
 The `ErrorTracker.Plugins.Pruner` module provides automatic pruning functionality with a configurable
 interval and error age.
 
-## Ignoring errors
+## Ignoring and Muting Errors
+
+ErrorTracker provides two different ways to silence errors:
+
+### Ignoring Errors
 
 ErrorTracker tracks every error by default. In certain cases some errors may be expected or just not interesting to track.
-ErrorTracker provides functionality that allows you to ignore errors based on their attributes and context.
+The `ErrorTracker.Ignorer` behaviour allows you to ignore errors based on their attributes and context.
 
-Take a look at the `ErrorTracker.Ignorer` behaviour for more information about how to implement your own ignorer.
+When an error is ignored, its occurrences are not tracked at all. This is useful for expected errors that you don't want to store in your database.
+
+### Muting Errors
+
+Sometimes you may want to keep tracking error occurrences but avoid receiving notifications about them. For these cases,
+ErrorTracker allows you to mute specific errors.
+
+When an error is muted:
+- New occurrences are still tracked and stored in the database
+- No telemetry events are emitted for new occurrences
+- You can still see the error and its occurrences in the web UI
+
+This is particularly useful for noisy errors that you want to keep tracking but don't want to receive notifications about.
+
+You can mute and unmute errors manually through the web UI or programmatically using the `ErrorTracker.mute/1` and `ErrorTracker.unmute/1` functions.

--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -170,8 +170,8 @@ ErrorTracker allows you to mute specific errors.
 
 When an error is muted:
 - New occurrences are still tracked and stored in the database
-- No telemetry events are emitted for new occurrences
 - You can still see the error and its occurrences in the web UI
+- [Telemetry events](ErrorTracker.Telemetry.html) for new occurrences include the `muted: true` flag so you can ignore them as needed.
 
 This is particularly useful for noisy errors that you want to keep tracking but don't want to receive notifications about.
 

--- a/lib/error_tracker.ex
+++ b/lib/error_tracker.ex
@@ -180,6 +180,26 @@ defmodule ErrorTracker do
   end
 
   @doc """
+  Mutes the error so next ocurrences won't send telemetry events.
+  """
+  @spec mute(Error.t()) :: {:ok, Error.t()} | {:error, Ecto.Changeset.t()}
+  def mute(error = %Error{muted: false}) do
+    changeset = Ecto.Changeset.change(error, muted: true)
+
+    Repo.update(changeset)
+  end
+
+  @doc """
+  Unmutes the error so next ocurrences will send telemetry events.
+  """
+  @spec unmute(Error.t()) :: {:ok, Error.t()} | {:error, Ecto.Changeset.t()}
+  def unmute(error = %Error{muted: true}) do
+    changeset = Ecto.Changeset.change(error, muted: false)
+
+    Repo.update(changeset)
+  end
+
+  @doc """
   Sets the current process context.
 
   The given context will be merged into the current process context. The given context

--- a/lib/error_tracker.ex
+++ b/lib/error_tracker.ex
@@ -177,7 +177,15 @@ defmodule ErrorTracker do
   end
 
   @doc """
-  Mutes the error so next ocurrences won't send telemetry events.
+  Mutes the error so new occurrences won't send telemetry events.
+
+  When an error is muted:
+  - New occurrences are still tracked and stored in the database
+  - No telemetry events are emitted for new occurrences
+  - You can still see the error and its occurrences in the web UI
+
+  This is useful for noisy errors that you want to keep tracking but don't want to
+  receive notifications about.
   """
   @spec mute(Error.t()) :: {:ok, Error.t()} | {:error, Ecto.Changeset.t()}
   def mute(error = %Error{}) do
@@ -187,7 +195,10 @@ defmodule ErrorTracker do
   end
 
   @doc """
-  Unmutes the error so next ocurrences will send telemetry events.
+  Unmutes the error so new occurrences will send telemetry events again.
+
+  This reverses the effect of `mute/1`, allowing telemetry events to be emitted
+  for new occurrences of this error again.
   """
   @spec unmute(Error.t()) :: {:ok, Error.t()} | {:error, Ecto.Changeset.t()}
   def unmute(error = %Error{}) do

--- a/lib/error_tracker/ignorer.ex
+++ b/lib/error_tracker/ignorer.ex
@@ -2,6 +2,12 @@ defmodule ErrorTracker.Ignorer do
   @moduledoc """
   Behaviour for ignoring errors.
 
+  > #### Ignoring vs muting errors {: .info}
+  >
+  > Ignoring an error keeps it from being tracked by the ErrorTracker. While this may be useful in
+  > certain cases, in other cases you may prefer to track the error but don't send telemetry events.
+  > Take a look at the `ErrorTracker.mute/1` function to see how to mute errors.
+
   The ErrorTracker tracks every error that happens in your application. In certain cases you may
   want to ignore some errors and don't track them. To do so you can implement this behaviour.
 

--- a/lib/error_tracker/migration/mysql.ex
+++ b/lib/error_tracker/migration/mysql.ex
@@ -7,7 +7,7 @@ defmodule ErrorTracker.Migration.MySQL do
   alias ErrorTracker.Migration.SQLMigrator
 
   @initial_version 3
-  @current_version 4
+  @current_version 5
 
   @impl ErrorTracker.Migration
   def up(opts) do

--- a/lib/error_tracker/migration/mysql/v05.ex
+++ b/lib/error_tracker/migration/mysql/v05.ex
@@ -1,0 +1,17 @@
+defmodule ErrorTracker.Migration.MySQL.V05 do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def up(_opts) do
+    alter table(:error_tracker_errors) do
+      add :muted, :boolean, default: false, null: false
+    end
+  end
+
+  def down(_opts) do
+    alter table(:error_tracker_errors) do
+      remove :muted
+    end
+  end
+end

--- a/lib/error_tracker/migration/postgres.ex
+++ b/lib/error_tracker/migration/postgres.ex
@@ -7,7 +7,7 @@ defmodule ErrorTracker.Migration.Postgres do
   alias ErrorTracker.Migration.SQLMigrator
 
   @initial_version 1
-  @current_version 4
+  @current_version 5
   @default_prefix "public"
 
   @impl ErrorTracker.Migration

--- a/lib/error_tracker/migration/postgres/v05.ex
+++ b/lib/error_tracker/migration/postgres/v05.ex
@@ -1,0 +1,17 @@
+defmodule ErrorTracker.Migration.Postgres.V05 do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def up(%{prefix: prefix}) do
+    alter table(:error_tracker_errors, prefix: prefix) do
+      add :muted, :boolean, default: false, null: false
+    end
+  end
+
+  def down(%{prefix: prefix}) do
+    alter table(:error_tracker_errors, prefix: prefix) do
+      remove :muted
+    end
+  end
+end

--- a/lib/error_tracker/migration/sqlite.ex
+++ b/lib/error_tracker/migration/sqlite.ex
@@ -7,7 +7,7 @@ defmodule ErrorTracker.Migration.SQLite do
   alias ErrorTracker.Migration.SQLMigrator
 
   @initial_version 2
-  @current_version 4
+  @current_version 5
 
   @impl ErrorTracker.Migration
   def up(opts) do

--- a/lib/error_tracker/migration/sqlite/v05.ex
+++ b/lib/error_tracker/migration/sqlite/v05.ex
@@ -1,0 +1,17 @@
+defmodule ErrorTracker.Migration.SQLite.V05 do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def up(_opts) do
+    alter table(:error_tracker_errors) do
+      add :muted, :boolean, default: false, null: false
+    end
+  end
+
+  def down(_opts) do
+    alter table(:error_tracker_errors) do
+      remove :muted
+    end
+  end
+end

--- a/lib/error_tracker/schemas/error.ex
+++ b/lib/error_tracker/schemas/error.ex
@@ -22,7 +22,7 @@ defmodule ErrorTracker.Error do
     field :status, Ecto.Enum, values: [:resolved, :unresolved], default: :unresolved
     field :fingerprint, :binary
     field :last_occurrence_at, :utc_datetime_usec
-    field :muted, :boolean, default: false
+    field :muted, :boolean
 
     has_many :occurrences, ErrorTracker.Occurrence
 

--- a/lib/error_tracker/schemas/error.ex
+++ b/lib/error_tracker/schemas/error.ex
@@ -22,7 +22,7 @@ defmodule ErrorTracker.Error do
     field :status, Ecto.Enum, values: [:resolved, :unresolved], default: :unresolved
     field :fingerprint, :binary
     field :last_occurrence_at, :utc_datetime_usec
-    field :muted, :boolean
+    field :muted, :boolean, default: false
 
     has_many :occurrences, ErrorTracker.Occurrence
 

--- a/lib/error_tracker/schemas/error.ex
+++ b/lib/error_tracker/schemas/error.ex
@@ -22,6 +22,7 @@ defmodule ErrorTracker.Error do
     field :status, Ecto.Enum, values: [:resolved, :unresolved], default: :unresolved
     field :fingerprint, :binary
     field :last_occurrence_at, :utc_datetime_usec
+    field :muted, :boolean
 
     has_many :occurrences, ErrorTracker.Occurrence
 

--- a/lib/error_tracker/telemetry.ex
+++ b/lib/error_tracker/telemetry.ex
@@ -31,39 +31,45 @@ defmodule ErrorTracker.Telemetry do
   Each event is emitted with some measures and metadata, which can be used to
   receive information without having to query the database again:
 
-  | event                                   | measures       | metadata      |
-  | --------------------------------------- | -------------- | ------------- |
-  | `[:error_tracker, :error, :new]`        | `:system_time` | `:error`      |
-  | `[:error_tracker, :error, :unresolved]` | `:system_time` | `:error`      |
-  | `[:error_tracker, :error, :resolved]`   | `:system_time` | `:error`      |
-  | `[:error_tracker, :occurrence, :new]`   | `:system_time` | `:occurrence` |
+  | event                                   | measures       | metadata                          |
+  | --------------------------------------- | -------------- | ----------------------------------|
+  | `[:error_tracker, :error, :new]`        | `:system_time` | `:error`                          |
+  | `[:error_tracker, :error, :unresolved]` | `:system_time` | `:error`                          |
+  | `[:error_tracker, :error, :resolved]`   | `:system_time` | `:error`                          |
+  | `[:error_tracker, :occurrence, :new]`   | `:system_time` | `:occurrence`, `:error`, `:muted` |
+
+  The metadata keys contain the following data:
+
+  * `:error` - An `%ErrorTracker.Error{}` struct representing the error.
+  * `:occurrence` - An `%ErrorTracker.Occurrence{}` struct representing the occurrence.
+  * `:muted` - A boolean indicating whether the error is muted or not.
   """
 
   @doc false
-  def new_error(error) do
+  def new_error(error = %ErrorTracker.Error{}) do
     measurements = %{system_time: System.system_time()}
     metadata = %{error: error}
     :telemetry.execute([:error_tracker, :error, :new], measurements, metadata)
   end
 
   @doc false
-  def unresolved_error(error) do
+  def unresolved_error(error = %ErrorTracker.Error{}) do
     measurements = %{system_time: System.system_time()}
     metadata = %{error: error}
     :telemetry.execute([:error_tracker, :error, :unresolved], measurements, metadata)
   end
 
   @doc false
-  def resolved_error(error) do
+  def resolved_error(error = %ErrorTracker.Error{}) do
     measurements = %{system_time: System.system_time()}
     metadata = %{error: error}
     :telemetry.execute([:error_tracker, :error, :resolved], measurements, metadata)
   end
 
   @doc false
-  def new_occurrence(occurrence) do
+  def new_occurrence(occurrence = %ErrorTracker.Occurrence{}, muted) when is_boolean(muted) do
     measurements = %{system_time: System.system_time()}
-    metadata = %{occurrence: occurrence}
+    metadata = %{error: occurrence.error, occurrence: occurrence, muted: muted}
     :telemetry.execute([:error_tracker, :occurrence, :new], measurements, metadata)
   end
 end

--- a/lib/error_tracker/web/components/core_components.ex
+++ b/lib/error_tracker/web/components/core_components.ex
@@ -130,4 +130,41 @@ defmodule ErrorTracker.Web.CoreComponents do
     </div>
     """
   end
+
+  attr :name, :string, values: ~w[bell bell-slash]
+
+  def icon(assigns = %{name: "bell"}) do
+    ~H"""
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      class="!h-4 !w-4 inline-block"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M12 5a4 4 0 0 0-8 0v2.379a1.5 1.5 0 0 1-.44 1.06L2.294 9.707a1 1 0 0 0-.293.707V11a1 1 0 0 0 1 1h2a3 3 0 1 0 6 0h2a1 1 0 0 0 1-1v-.586a1 1 0 0 0-.293-.707L12.44 8.44A1.5 1.5 0 0 1 12 7.38V5Zm-5.5 7a1.5 1.5 0 0 0 3 0h-3Z"
+        clip-rule="evenodd"
+      />
+    </svg>
+    """
+  end
+
+  def icon(assigns = %{name: "bell-slash"}) do
+    ~H"""
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      class="!h-4 !w-4 inline-block"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M4 7.379v-.904l6.743 6.742A3 3 0 0 1 5 12H3a1 1 0 0 1-1-1v-.586a1 1 0 0 1 .293-.707L3.56 8.44A1.5 1.5 0 0 0 4 7.38ZM6.5 12a1.5 1.5 0 0 0 3 0h-3Z"
+        clip-rule="evenodd"
+      />
+      <path d="M14 11a.997.997 0 0 1-.096.429L4.92 2.446A4 4 0 0 1 12 5v2.379c0 .398.158.779.44 1.06l1.267 1.268a1 1 0 0 1 .293.707V11ZM2.22 2.22a.75.75 0 0 1 1.06 0l10.5 10.5a.75.75 0 1 1-1.06 1.06L2.22 3.28a.75.75 0 0 1 0-1.06Z" />
+    </svg>
+    """
+  end
 end

--- a/lib/error_tracker/web/live/dashboard.ex
+++ b/lib/error_tracker/web/live/dashboard.ex
@@ -57,6 +57,22 @@ defmodule ErrorTracker.Web.Live.Dashboard do
     {:noreply, paginate_errors(socket)}
   end
 
+  @impl Phoenix.LiveView
+  def handle_event("mute", %{"error_id" => id}, socket) do
+    error = Repo.get(Error, id)
+    {:ok, _muted} = ErrorTracker.mute(error)
+
+    {:noreply, paginate_errors(socket)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("unmute", %{"error_id" => id}, socket) do
+    error = Repo.get(Error, id)
+    {:ok, _unmuted} = ErrorTracker.unmute(error)
+
+    {:noreply, paginate_errors(socket)}
+  end
+
   defp paginate_errors(socket) do
     %{page: page, search: search} = socket.assigns
     offset = (page - 1) * @per_page

--- a/lib/error_tracker/web/live/dashboard.html.heex
+++ b/lib/error_tracker/web/live/dashboard.html.heex
@@ -87,29 +87,36 @@
           <.badge :if={error.status == :unresolved} color={:red}>Unresolved</.badge>
         </td>
         <td class="px-4 py-4 text-center">
-          <.button
-            :if={error.status == :unresolved}
-            phx-click="resolve"
-            phx-value-error_id={error.id}
-          >
-            Resolve
-          </.button>
+          <div class="flex justify-between">
+            <.button
+              :if={error.status == :unresolved}
+              phx-click="resolve"
+              phx-value-error_id={error.id}
+            >
+              Resolve
+            </.button>
 
-          <.button
-            :if={error.status == :resolved}
-            phx-click="unresolve"
-            phx-value-error_id={error.id}
-          >
-            Unresolve
-          </.button>
+            <.button
+              :if={error.status == :resolved}
+              phx-click="unresolve"
+              phx-value-error_id={error.id}
+            >
+              Unresolve
+            </.button>
 
-          <.button :if={!error.muted} phx-click="mute" type="link" phx-value-error_id={error.id}>
-            Mute
-          </.button>
+            <.button :if={!error.muted} phx-click="mute" type="link" phx-value-error_id={error.id}>
+              <.icon name="bell-slash" /> Mute
+            </.button>
 
-          <.button :if={error.muted} phx-click="unmute" type="link" phx-value-error_id={error.id}>
-            Unmute
-          </.button>
+            <.button
+              :if={error.muted}
+              phx-click="unmute"
+              type="link"
+              phx-value-error_id={error.id}
+            >
+              <.icon name="bell" /> Unmute
+            </.button>
+          </div>
         </td>
       </tr>
     </tbody>

--- a/lib/error_tracker/web/live/dashboard.html.heex
+++ b/lib/error_tracker/web/live/dashboard.html.heex
@@ -102,6 +102,14 @@
           >
             Unresolve
           </.button>
+
+          <.button :if={!error.muted} phx-click="mute" type="link" phx-value-error_id={error.id}>
+            Mute
+          </.button>
+
+          <.button :if={error.muted} phx-click="unmute" type="link" phx-value-error_id={error.id}>
+            Unmute
+          </.button>
         </td>
       </tr>
     </tbody>

--- a/lib/error_tracker/web/live/show.ex
+++ b/lib/error_tracker/web/live/show.ex
@@ -69,6 +69,20 @@ defmodule ErrorTracker.Web.Live.Show do
     {:noreply, assign(socket, :error, updated_error)}
   end
 
+  @impl Phoenix.LiveView
+  def handle_event("mute", _params, socket) do
+    {:ok, updated_error} = ErrorTracker.mute(socket.assigns.error)
+
+    {:noreply, assign(socket, :error, updated_error)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("unmute", _params, socket) do
+    {:ok, updated_error} = ErrorTracker.unmute(socket.assigns.error)
+
+    {:noreply, assign(socket, :error, updated_error)}
+  end
+
   defp load_related_occurrences(socket) do
     current_occurrence = socket.assigns.occurrence
     base_query = Ecto.assoc(socket.assigns.error, :occurrences)

--- a/lib/error_tracker/web/live/show.html.heex
+++ b/lib/error_tracker/web/live/show.html.heex
@@ -117,21 +117,23 @@
     </.section>
 
     <.section>
-      <.button :if={@error.status == :unresolved} phx-click="resolve">
-        Mark as resolved
-      </.button>
+      <div class="flex flex-col gap-y-4">
+        <.button :if={@error.status == :unresolved} phx-click="resolve">
+          Mark as resolved
+        </.button>
 
-      <.button :if={@error.status == :resolved} phx-click="unresolve">
-        Mark as unresolved
-      </.button>
+        <.button :if={@error.status == :resolved} phx-click="unresolve">
+          Mark as unresolved
+        </.button>
 
-      <.button :if={!@error.muted} phx-click="mute" type="link">
-        Mute
-      </.button>
+        <.button :if={!@error.muted} phx-click="mute" type="link">
+          <.icon name="bell-slash" /> Mute
+        </.button>
 
-      <.button :if={@error.muted} phx-click="unmute" type="link">
-        Unmute
-      </.button>
+        <.button :if={@error.muted} phx-click="unmute" type="link">
+          <.icon name="bell" /> Unmute
+        </.button>
+      </div>
     </.section>
   </div>
 </div>

--- a/lib/error_tracker/web/live/show.html.heex
+++ b/lib/error_tracker/web/live/show.html.heex
@@ -124,6 +124,14 @@
       <.button :if={@error.status == :resolved} phx-click="unresolve">
         Mark as unresolved
       </.button>
+
+      <.button :if={!@error.muted} phx-click="mute" type="link">
+        Mute
+      </.button>
+
+      <.button :if={@error.muted} phx-click="unmute" type="link">
+        Unmute
+      </.button>
     </.section>
   </div>
 </div>

--- a/priv/static/app.css
+++ b/priv/static/app.css
@@ -873,12 +873,20 @@ select {
   display: none;
 }
 
+.\!h-4 {
+  height: 1rem !important;
+}
+
 .h-10 {
   height: 2.5rem;
 }
 
 .h-5 {
   height: 1.25rem;
+}
+
+.\!w-4 {
+  width: 1rem !important;
 }
 
 .w-10 {
@@ -943,6 +951,10 @@ select {
 
 .gap-2 {
   gap: 0.5rem;
+}
+
+.gap-y-4 {
+  row-gap: 1rem;
 }
 
 .space-y-8 > :not([hidden]) ~ :not([hidden]) {

--- a/test/error_tracker/telemetry_test.exs
+++ b/test/error_tracker/telemetry_test.exs
@@ -11,22 +11,36 @@ defmodule ErrorTracker.TelemetryTest do
   end
 
   test "events are emitted for new errors" do
+    {exception, stacktrace} =
+      try do
+        raise "This is a test"
+      rescue
+        e -> {e, __STACKTRACE__}
+      end
+
     # Since the error is new, both the new error and new occurrence events will be emitted
-    report_error(fn -> raise "This is a test" end)
+    %Occurrence{error: error = %Error{}} = ErrorTracker.report(exception, stacktrace)
     assert_receive {:telemetry_event, [:error_tracker, :error, :new], _, %{error: %Error{}}}
 
     assert_receive {:telemetry_event, [:error_tracker, :occurrence, :new], _,
                     %{occurrence: %Occurrence{}}}
 
     # The error is already known so the new error event won't be emitted
-    report_error(fn -> raise "This is a test" end)
+    ErrorTracker.report(exception, stacktrace)
 
-    refute_receive {:telemetry_event, [:error_tracker, :error, :new], _,
-                    %{occurrence: %Occurrence{}}},
+    refute_receive {:telemetry_event, [:error_tracker, :error, :new], _, %{error: %Error{}}},
                    150
 
     assert_receive {:telemetry_event, [:error_tracker, :occurrence, :new], _,
                     %{occurrence: %Occurrence{}}}
+
+    # The error is muted so the new occurrence event won't be emitted
+    ErrorTracker.mute(error)
+    ErrorTracker.report(exception, stacktrace)
+
+    refute_receive {:telemetry_event, [:error_tracker, :occurrence, :new], _,
+                    %{occurrence: %Occurrence{}}},
+                   150
   end
 
   test "events are emitted for resolved and unresolved errors" do

--- a/test/error_tracker/telemetry_test.exs
+++ b/test/error_tracker/telemetry_test.exs
@@ -23,7 +23,7 @@ defmodule ErrorTracker.TelemetryTest do
     assert_receive {:telemetry_event, [:error_tracker, :error, :new], _, %{error: %Error{}}}
 
     assert_receive {:telemetry_event, [:error_tracker, :occurrence, :new], _,
-                    %{occurrence: %Occurrence{}}}
+                    %{occurrence: %Occurrence{}, muted: false}}
 
     # The error is already known so the new error event won't be emitted
     ErrorTracker.report(exception, stacktrace)
@@ -32,15 +32,14 @@ defmodule ErrorTracker.TelemetryTest do
                    150
 
     assert_receive {:telemetry_event, [:error_tracker, :occurrence, :new], _,
-                    %{occurrence: %Occurrence{}}}
+                    %{occurrence: %Occurrence{}, muted: false}}
 
-    # The error is muted so the new occurrence event won't be emitted
+    # The error is muted so the new occurrence event will include the muted=true metadata
     ErrorTracker.mute(error)
     ErrorTracker.report(exception, stacktrace)
 
-    refute_receive {:telemetry_event, [:error_tracker, :occurrence, :new], _,
-                    %{occurrence: %Occurrence{}}},
-                   150
+    assert_receive {:telemetry_event, [:error_tracker, :occurrence, :new], _,
+                    %{occurrence: %Occurrence{}, muted: true}}
   end
 
   test "events are emitted for resolved and unresolved errors" do


### PR DESCRIPTION
This pull request adds a new `muted` field to errors. Noisy errors can be muted in the UI so integrations and notifications can ignore them as well.

In the end I decided to use the _mute_ instead of _silence_ as I think that _mute_ and _unmute_ are fairly commonly understood terms.

This is an addition to the capability of ignoring errors that we already have, and enables the possibility of tracking error occurrences but don't notify them. Closes #117


New mute action in the error detail page:
<img width="1552" alt="New mute action in the error detail page" src="https://github.com/user-attachments/assets/11663fcc-e233-4746-b5c2-a8fa7e233e3a" />

Mute and unmute actions in the dashboard page
<img width="1552" alt="Mute and unmute actions in the dashboard page" src="https://github.com/user-attachments/assets/182f9add-e72c-44aa-9e6f-3769b4f88f71" />

