### PR TITLE
Fix error grouping issue

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -83,8 +83,8 @@ jobs:
       - name: Check application compile warnings
         run: mix compile --force --warnings-as-errors
 
-      # - name: Check Credo warnings
-      #   run: mix credo
+      - name: Check Credo warnings
+        run: mix credo
 
       - name: Run Tests - SQLite3
         run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -83,8 +83,8 @@ jobs:
       - name: Check application compile warnings
         run: mix compile --force --warnings-as-errors
 
-      - name: Check Credo warnings
-        run: mix credo
+      # - name: Check Credo warnings
+      #   run: mix credo
 
       - name: Run Tests - SQLite3
         run: mix test

--- a/lib/error_tracker/schemas/stacktrace.ex
+++ b/lib/error_tracker/schemas/stacktrace.ex
@@ -55,7 +55,7 @@ defmodule ErrorTracker.Stacktrace do
   application, just the first line.
   """
   def source(stack = %__MODULE__{}) do
-    client_app = Application.fetch_env!(:error_tracker, :otp_app)
+    client_app = Application.fetch_env!(:error_tracker, :otp_app) |> to_string()
 
     Enum.find(stack.lines, &(&1.application == client_app)) || List.first(stack.lines)
   end

--- a/test/error_tracker_test.exs
+++ b/test/error_tracker_test.exs
@@ -38,11 +38,21 @@ defmodule ErrorTrackerTest do
       assert error.kind == to_string(ArithmeticError)
       assert error.reason == "bad argument in arithmetic expression"
 
-      assert last_line.module == "erlang"
-      assert last_line.function == "+"
-      assert last_line.arity == 2
-      refute last_line.file
-      refute last_line.line
+      # Elixir 1.17.0 reports these errors differently than previous versions
+      if Version.compare(System.version(), "1.17.0") == :lt do
+        dbg(last_line)
+        assert last_line.module == "Elixir.ErrorTrackerTest"
+        assert last_line.function == "report_error/2"
+        assert last_line.arity == 1
+        assert last_line.file == @relative_file_path
+        assert last_line.line == 11
+      else
+        assert last_line.module == "erlang"
+        assert last_line.function == "+"
+        assert last_line.arity == 2
+        refute last_line.file
+        refute last_line.line
+      end
     end
 
     test "reports undefined function errors" do

--- a/test/error_tracker_test.exs
+++ b/test/error_tracker_test.exs
@@ -40,12 +40,11 @@ defmodule ErrorTrackerTest do
 
       # Elixir 1.17.0 reports these errors differently than previous versions
       if Version.compare(System.version(), "1.17.0") == :lt do
-        dbg(last_line)
-        assert last_line.module == "Elixir.ErrorTrackerTest"
-        assert last_line.function == "report_error/2"
+        assert last_line.module == "ErrorTrackerTest"
+        assert last_line.function =~ "&ErrorTracker.report/3 reports badarith errors"
         assert last_line.arity == 1
-        assert last_line.file == @relative_file_path
-        assert last_line.line == 11
+        assert last_line.file
+        assert last_line.line
       else
         assert last_line.module == "erlang"
         assert last_line.function == "+"


### PR DESCRIPTION
The errors are being grouped in a wrong way because a type mismatch comparison was done between the application name and the stacktrace application name.

The fix is to convert the configured application name to a string and be able to compare it with the stacktrace application name.

You can test it putting this script on the root project:

<details>

```elixir
Mix.install([
  {:ecto_sql, "~> 3.0"},
  {:postgrex, "~> 0.1"},
  {:error_tracker, path: "."},
  {:bandit, "~> 1.0"}
])

### ErrorLogger config

Application.put_env(:error_tracker, :repo, Repo)
Application.put_env(:error_tracker, :otp_app, :myapp)
Application.put_env(:error_tracker, :enabled, true)

defmodule AddErrorTracker do
  use Ecto.Migration

  def up, do: ErrorTracker.Migration.up(version: 4)

  def down, do: ErrorTracker.Migration.down(version: 1)
end

### Common config

Application.put_env(:myapp, Repo, database: "mix_install_examples")

defmodule Repo do
  use Ecto.Repo, adapter: Ecto.Adapters.Postgres, otp_app: :myapp
end

defmodule Migration0 do
  use Ecto.Migration

  def change do
    create table("posts") do
      add(:title, :string)
      timestamps(type: :utc_datetime_usec)
    end
  end
end

defmodule Post do
  use Ecto.Schema

  schema "posts" do
    field(:title, :string)
    timestamps(type: :utc_datetime_usec)
  end
end

defmodule Main do
  import Ecto.Query, warn: false

  def migrate do
    Repo.__adapter__().storage_down(Repo.config())
    :ok = Repo.__adapter__().storage_up(Repo.config())
    {:ok, _} = Repo.start_link([])
    Ecto.Migrator.run(Repo, [{0, Migration0}, {1, AddErrorTracker}], :up, all: true, log_migrations_sql: :info)
  end

  def register_app_and_modules do
    :application.load({:application, :myapp, [
      {:description, ~c"My sample application"},
      {:vsn, ~c"0.1.0"},
      {:modules, [Router]},
      {:registered, [Router]},
      {:applications, [:kernel, :stdlib]}
    ]})
  end

  def run_http_server do
    Supervisor.start_link([{Bandit, [plug: Router, port: 1234]}], strategy: :one_for_one)
  end

  def make_requests do
    :inets.start()
    :httpc.request("http://localhost:1234/route1")
    :httpc.request("http://localhost:1234/route2")
  end

  def check_what_was_collected do
    ErrorTracker.Error
    |> Repo.all()
    |> IO.inspect()

    ErrorTracker.Occurrence
    |> Repo.all()
    |> Enum.map(&Enum.take(&1.stacktrace.lines, 2))
    |> IO.inspect()
  end
end

defmodule Router do
  use Plug.Router
  use ErrorTracker.Integrations.Plug

  plug(:match)
  plug(:dispatch)

  get "/route1" do
    Repo.get!(Post, 1)
    send_resp(conn, 200, "Anything")
  end

  get "/route2" do
    Repo.get!(Post, 2)
    send_resp(conn, 200, "Anything")
  end
end

Main.migrate()
Main.register_app_and_modules()
Main.run_http_server()
Main.make_requests()
Main.check_what_was_collected() # <- demonstrates the issue

Process.sleep(:infinity)
```

</details>

This closes #132 