### PR TITLE
Improve documentation of ErrorTracker.Error kind field

### DIFF
--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -163,6 +163,19 @@ The `ErrorTracker.Ignorer` behaviour allows you to ignore errors based on their 
 
 When an error is ignored, its occurrences are not tracked at all. This is useful for expected errors that you don't want to store in your database.
 
+For example, if you had an integration with an unreliable third-party system that was frequently timing out, you could ignore those errors like so:
+
+```elixir
+defmodule MyApp.ErrorIgnores do
+  @behaviour ErrorTracker.Ignorer
+
+  @impl ErrorTracker.Ignorer
+  def ignore?(%{kind: "Elixir.UnreliableThirdParty.Error", reason: ":timeout"} = _error, _context) do
+    true
+  end
+end
+```
+
 ### Muting Errors
 
 Sometimes you may want to keep tracking error occurrences but avoid receiving notifications about them. For these cases,

--- a/lib/error_tracker/schemas/error.ex
+++ b/lib/error_tracker/schemas/error.ex
@@ -12,7 +12,13 @@ defmodule ErrorTracker.Error do
 
   use Ecto.Schema
 
-  @type t :: %__MODULE__{}
+  @type t :: %__MODULE__{
+    kind: string(),
+    reason: string(),
+    source_line: string(),
+    source_function: string(),
+    status: :resolved | :unresolved
+  }
 
   schema "error_tracker_errors" do
     field :kind, :string

--- a/lib/error_tracker/schemas/error.ex
+++ b/lib/error_tracker/schemas/error.ex
@@ -17,7 +17,10 @@ defmodule ErrorTracker.Error do
           reason: String.t(),
           source_line: String.t(),
           source_function: String.t(),
-          status: :resolved | :unresolved
+          status: :resolved | :unresolved,
+          fingerprint: String.t(),
+          last_occurrence_at: DateTime.t(),
+          muted: boolean()
         }
 
   schema "error_tracker_errors" do

--- a/lib/error_tracker/schemas/error.ex
+++ b/lib/error_tracker/schemas/error.ex
@@ -13,12 +13,12 @@ defmodule ErrorTracker.Error do
   use Ecto.Schema
 
   @type t :: %__MODULE__{
-    kind: string(),
-    reason: string(),
-    source_line: string(),
-    source_function: string(),
-    status: :resolved | :unresolved
-  }
+          kind: String.t(),
+          reason: String.t(),
+          source_line: String.t(),
+          source_function: String.t(),
+          status: :resolved | :unresolved
+        }
 
   schema "error_tracker_errors" do
     field :kind, :string


### PR DESCRIPTION
This addresses #153.

We thought about it and came to the conclusion that it would be good to change the type declaration for the module. Open for discussion, because that could potentially be a breaking change of the library if users previously had implementations of `ErrorTracker.Ignorer` that matched on non-string types (although, arguably those implementations would never have worked).