### PR TITLE
chore: Run test matrix on Elixir 1.20.x

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -28,6 +28,8 @@ jobs:
             erlang: "27.x"
           - elixir: "1.19.x"
             erlang: "28.x"
+          - elixir: "latest"
+            erlang: "28.x"
     services:
       db:
         image: postgres:15

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -88,16 +88,16 @@ jobs:
         run: mix compile --force --warnings-as-errors
 
       - name: Run Tests - SQLite3
-        run: mix test
+        run: mix test --warnings-as-errors
         env:
           DB: sqlite
 
       - name: Run Tests - PostgreSQL
-        run: mix test
+        run: mix test --warnings-as-errors
         env:
           DB: postgres
 
       - name: Run Tests - MySQL/MariaDB
-        run: mix test
+        run: mix test --warnings-as-errors
         env:
           DB: mysql


### PR DESCRIPTION
The first RC of Elixir 1.20 has [just been released](https://elixir-lang.org/blog/2026/01/09/type-inference-of-all-and-next-15/)

Running the CI on that version will allow us to catch type errors quickly and fix them before 1.20 is officially released.