### PR TITLE
fix: Improve sensitive header redaction

### DIFF
--- a/lib/error_tracker/integrations/plug.ex
+++ b/lib/error_tracker/integrations/plug.ex
@@ -111,7 +111,7 @@ defmodule ErrorTracker.Integrations.Plug do
     conn |> build_context() |> ErrorTracker.set_context()
   end
 
-  @sensitive_headers ["cookie", "authorization"]
+  @sensitive_headers ~w[authorization cookie set-cookie]
 
   defp build_context(%Plug.Conn{} = conn) do
     %{
@@ -120,7 +120,10 @@ defmodule ErrorTracker.Integrations.Plug do
       "request.query" => conn.query_string,
       "request.method" => conn.method,
       "request.ip" => remote_ip(conn),
-      "request.headers" => conn.req_headers |> Map.new() |> Map.drop(@sensitive_headers),
+      "request.headers" =>
+        Map.new(conn.req_headers, fn {header, value} ->
+          if header in @sensitive_headers, do: {header, "[REDACTED]"}, else: {header, value}
+        end),
       # Depending on the error source, the request params may have not been fetched yet
       "request.params" => if(!is_struct(conn.params, Plug.Conn.Unfetched), do: conn.params)
     }

--- a/test/integrations/plug_test.exs
+++ b/test/integrations/plug_test.exs
@@ -47,11 +47,8 @@ defmodule ErrorTracker.Integrations.PlugTest do
 
     [occurrence] = repo().all(ErrorTracker.Occurrence)
 
-    header_names = occurrence.context |> Map.get("request.headers") |> Map.keys()
-
-    refute "cookie" in header_names
-    refute "authorization" in header_names
-
-    assert "safe" in header_names
+    assert occurrence.context["request.headers"]["cookie"] == "[REDACTED]"
+    assert occurrence.context["request.headers"]["authorization"] == "[REDACTED]"
+    assert occurrence.context["request.headers"]["safe"] != "[REDACTED]"
   end
 end


### PR DESCRIPTION
We now redact headers instead of just dropping them. This allows users of the Error Tracker to know wether a header was present or not. With the previous logic it was impossible to know wether the header was dropped or not present in the first place.

We also redact the `set-cookie` header so we redact outgoing cookies and not only incoming cookies as per the `cookie` header.

This PR replaces #166 