### PR TITLE
Include occurrence in error telemetry events

### DIFF
--- a/lib/error_tracker.ex
+++ b/lib/error_tracker.ex
@@ -377,7 +377,7 @@ defmodule ErrorTracker do
     case existing_status do
       :resolved -> Telemetry.unresolved_error(error)
       :unresolved -> :noop
-      nil -> Telemetry.new_error(error)
+      nil -> Telemetry.new_error(error, occurrence)
     end
 
     Telemetry.new_occurrence(occurrence, muted)

--- a/lib/error_tracker.ex
+++ b/lib/error_tracker.ex
@@ -375,7 +375,7 @@ defmodule ErrorTracker do
     # sent a Telemetry event
     # If it is a new error, sent a Telemetry event
     case existing_status do
-      :resolved -> Telemetry.unresolved_error(error)
+      :resolved -> Telemetry.previously_resolved_error(error, occurrence)
       :unresolved -> :noop
       nil -> Telemetry.new_error(error, occurrence)
     end

--- a/lib/error_tracker/telemetry.ex
+++ b/lib/error_tracker/telemetry.ex
@@ -55,7 +55,14 @@ defmodule ErrorTracker.Telemetry do
   @doc false
   def unresolved_error(%ErrorTracker.Error{} = error) do
     measurements = %{system_time: System.system_time()}
-    metadata = %{error: error}
+    metadata = %{error: error, occurrence: nil}
+    :telemetry.execute([:error_tracker, :error, :unresolved], measurements, metadata)
+  end
+
+  @doc false
+  def previously_resolved_error(%ErrorTracker.Error{} = error, %ErrorTracker.Occurrence{} = occurrence) do
+    measurements = %{system_time: System.system_time()}
+    metadata = %{error: error, occurrence: occurrence}
     :telemetry.execute([:error_tracker, :error, :unresolved], measurements, metadata)
   end
 

--- a/lib/error_tracker/telemetry.ex
+++ b/lib/error_tracker/telemetry.ex
@@ -31,17 +31,20 @@ defmodule ErrorTracker.Telemetry do
   Each event is emitted with some measures and metadata, which can be used to
   receive information without having to query the database again:
 
-  | event                                   | measures       | metadata                          |
-  | --------------------------------------- | -------------- | ----------------------------------|
-  | `[:error_tracker, :error, :new]`        | `:system_time` | `:error`                          |
-  | `[:error_tracker, :error, :unresolved]` | `:system_time` | `:error`                          |
-  | `[:error_tracker, :error, :resolved]`   | `:system_time` | `:error`                          |
-  | `[:error_tracker, :occurrence, :new]`   | `:system_time` | `:occurrence`, `:error`, `:muted` |
+  | event                                   | measures       | metadata                                        |
+  | --------------------------------------- | -------------- | ----------------------------------------------- |
+  | `[:error_tracker, :error, :new]`        | `:system_time` | `:error`, `:occurrence`                         |
+  | `[:error_tracker, :error, :unresolved]` | `:system_time` | `:error`, `:occurrence` (nullable)              |
+  | `[:error_tracker, :error, :resolved]`   | `:system_time` | `:error`                                        |
+  | `[:error_tracker, :occurrence, :new]`   | `:system_time` | `:occurrence`, `:error`, `:muted`               |
 
   The metadata keys contain the following data:
 
   * `:error` - An `%ErrorTracker.Error{}` struct representing the error.
   * `:occurrence` - An `%ErrorTracker.Occurrence{}` struct representing the occurrence.
+    For `:new` error events this is the first occurrence. For `:unresolved` events this
+    is the occurrence that triggered the state change, or `nil` when the error was manually
+    unresolved from the UI.
   * `:muted` - A boolean indicating whether the error is muted or not.
   """
 

--- a/lib/error_tracker/telemetry.ex
+++ b/lib/error_tracker/telemetry.ex
@@ -46,9 +46,9 @@ defmodule ErrorTracker.Telemetry do
   """
 
   @doc false
-  def new_error(%ErrorTracker.Error{} = error) do
+  def new_error(%ErrorTracker.Error{} = error, %ErrorTracker.Occurrence{} = occurrence) do
     measurements = %{system_time: System.system_time()}
-    metadata = %{error: error}
+    metadata = %{error: error, occurrence: occurrence}
     :telemetry.execute([:error_tracker, :error, :new], measurements, metadata)
   end
 

--- a/test/error_tracker/telemetry_test.exs
+++ b/test/error_tracker/telemetry_test.exs
@@ -19,8 +19,8 @@ defmodule ErrorTracker.TelemetryTest do
       end
 
     # Since the error is new, both the new error and new occurrence events will be emitted
-    %Occurrence{error: error = %Error{}} = ErrorTracker.report(exception, stacktrace)
-    assert_receive {:telemetry_event, [:error_tracker, :error, :new], _, %{error: %Error{}}}
+    occurrence = %Occurrence{error: error = %Error{}} = ErrorTracker.report(exception, stacktrace)
+    assert_receive {:telemetry_event, [:error_tracker, :error, :new], _, %{error: %Error{}, occurrence: ^occurrence}}
 
     assert_receive {:telemetry_event, [:error_tracker, :occurrence, :new], _, %{occurrence: %Occurrence{}, muted: false}}
 

--- a/test/error_tracker/telemetry_test.exs
+++ b/test/error_tracker/telemetry_test.exs
@@ -49,6 +49,27 @@ defmodule ErrorTracker.TelemetryTest do
     # The unresolved event will be emitted
     {:ok, _unresolved} = ErrorTracker.unresolve(resolved)
 
-    assert_receive {:telemetry_event, [:error_tracker, :error, :unresolved], _, %{error: %Error{}}}
+    assert_receive {:telemetry_event, [:error_tracker, :error, :unresolved], _, %{error: %Error{}, occurrence: nil}}
+  end
+
+  test "events are emitted for previously resolved errors" do
+    {exception, stacktrace} =
+      try do
+        raise "This error was resolved but came back"
+      rescue
+        e -> {e, __STACKTRACE__}
+      end
+
+    %Occurrence{error: error = %Error{}} = ErrorTracker.report(exception, stacktrace)
+
+    ErrorTracker.resolve(error)
+
+    occurrence = ErrorTracker.report(exception, stacktrace)
+
+    assert_receive {:telemetry_event, [:error_tracker, :error, :unresolved], _,
+                    %{
+                      error: %Error{reason: "This error was resolved but came back"},
+                      occurrence: ^occurrence
+                    }}
   end
 end


### PR DESCRIPTION
Hi @crbelaus,

We're a team that uses ErrorTracker, and we rely on its telemetry events to drive our alerting. 

First off, thank you for building and maintaining this library, it's been great to use and work with!

We ran into a situation where the `:new` and `:unresolved` error events didn't carry enough information for us to make good alerting decisions. Specifically, we want to tell whether an error is genuinely new vs a
repeat, and when a previously-resolved error comes back we want to use alert routing based on the the occurrence's `context`.

The `[:error_tracker, :occurrence, :new]` event does carry the occurrence, but it fires for every occurrence regardless of whether the error is new, returning, or already known. So it wasn't the right signal for our use case.

We've been running a fork with these changes for a while and it's worked well for us. We wanted to offer this upstream in case you find the direction acceptable. We're happy to adjust the approach if you'd prefer
a different shape or semantics, please consider this a humble proposal rather than a prescription.

## Changes

The `:new` and `:unresolved` error telemetry events now include the `:occurrence` in their metadata:

- **`:new` events** carry the first occurrence, so consumers can inspect its context immediately.
- **`:unresolved` events** (previously-resolved error re-occurs) carry the triggering occurrence.
- **`:unresolved` events** (manual unresolve via UI) carry `occurrence: nil` since no new occurrence is involved.

The `:resolved` event is unchanged (no occurrence is relevant there).

## Test plan

- Existing telemetry test updated to assert `:occurrence` in `:new` event metadata.
- Existing resolve/unresolve test updated to assert `occurrence: nil` for manual unresolves.
- New test added for the "previously resolved error re-occurs" scenario.
- Full suite passes with `--warnings-as-errors`