### PR TITLE
chore: Add Release Please action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
+          release-type: elixir


### PR DESCRIPTION
Adds the [release-please-action](https://github.com/googleapis/release-please-action) so it automates CHANGELOG generation, the creation of GitHub releases, and version bumps for your projects.

It does so by parsing the git history, looking for [Conventional Commit messages](https://www.conventionalcommits.org/), and creating release PRs.