### PR TITLE
fix: Formatter config depending in Mix breaks formatter

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,10 +1,6 @@
 # Used by "mix format"
 locals_without_parens = [error_tracker_dashboard: 1, error_tracker_dashboard: 2]
 
-# Parse SemVer minor elixir version from project configuration
-# eg `"~> 1.15"` version requirement will yield `"1.15"`
-[elixir_minor_version | _] = Regex.run(~r/([\d\.]+)/, Mix.Project.config()[:elixir])
-
 [
   import_deps: [:ecto, :ecto_sql, :plug, :phoenix],
   inputs: ["{mix,.formatter,dev,dev.*}.exs", "{config,lib,test}/**/*.{heex,ex,exs}"],
@@ -12,6 +8,6 @@ locals_without_parens = [error_tracker_dashboard: 1, error_tracker_dashboard: 2]
   locals_without_parens: locals_without_parens,
   export: [locals_without_parens: locals_without_parens],
   styler: [
-    minimum_supported_elixir_version: "#{elixir_minor_version}.0"
+    minimum_supported_elixir_version: "1.15.0"
   ]
 ]


### PR DESCRIPTION
When using `error_tracker` in other projects and telling the formatter to import the config from `:error_tracker` dependency causes ExpertLS to break and not applying styles properly.

Debugging locally I found that it is because of the Elixir version autodetect we use. This pull request is removing that, as we:
- are not updating it regularly
- if we import the config on projects using error_tracker we do not need to get the minimum elixir version on that project.